### PR TITLE
Add true-z summary statistics (mean, quantiles) to tomography metadata for photo-z bins

### DIFF
--- a/src/binny/utils/metadata.py
+++ b/src/binny/utils/metadata.py
@@ -76,6 +76,8 @@ def build_tomo_bins_metadata(
         int(k): np.asarray(v, dtype=float).tolist() for k, v in bins_returned.items()
     }
 
+    truez_summary = _compute_effective_truez(z_arr, bins_returned)
+
     meta: dict[str, Any] = {
         "kind": kind,
         "grid": {
@@ -105,12 +107,15 @@ def build_tomo_bins_metadata(
             "count_per_bin": None
             if count_per_bin is None
             else {int(k): float(v) for k, v in count_per_bin.items()},
+            "truez_summary": truez_summary,
         },
         "inputs": dict(inputs),
     }
 
     if notes is not None:
         meta["notes"] = dict(notes)
+
+    meta["description"] = _metadata_description()
 
     return meta
 
@@ -174,3 +179,186 @@ def save_metadata_txt(
     rounded = round_floats(dict(meta), decimal_places)
     p.write_text(_format(rounded) + "\n", encoding="utf-8")
     return p
+
+
+def _weighted_quantile(
+    z: np.ndarray,
+    pdf: np.ndarray,
+    q: float,
+) -> float | None:
+    """Return the quantile of a 1D probability distribution on a grid.
+
+    This function computes the quantile corresponding to cumulative probability
+    ``q`` for a distribution defined by ``pdf`` evaluated on a grid ``z``.
+    The distribution is interpreted as a continuous function and normalized
+    internally using trapezoidal integration.
+
+    The cumulative distribution function (CDF) is constructed via trapezoidal
+    integration, and the quantile is obtained by interpolation.
+
+    Args:
+        z: Monotonic 1D array representing the grid (e.g., redshift).
+        pdf: 1D array of the same shape as ``z`` representing the probability
+            density evaluated on the grid. Does not need to be normalized.
+        q: Desired quantile in the interval [0, 1].
+
+    Returns:
+        The value of ``z`` at which the cumulative probability reaches ``q``.
+        Returns ``None`` if the input distribution has zero total weight or if
+        the grid is empty.
+
+    Raises:
+        ValueError: If ``z`` and ``pdf`` have different shapes.
+    """
+    if z.size == 0:
+        return None
+
+    area = float(np.trapezoid(pdf, z))
+    if area <= 0.0:
+        return None
+
+    pdf_norm = pdf / area
+
+    if z.size == 1:
+        return float(z[0])
+
+    dz = np.diff(z)
+    cdf = np.empty_like(z, dtype=float)
+    cdf[0] = 0.0
+    cdf[1:] = np.cumsum(0.5 * (pdf_norm[:-1] + pdf_norm[1:]) * dz)
+
+    total = cdf[-1]
+    if total <= 0.0:
+        return None
+
+    cdf = cdf / total
+    return float(np.interp(q, cdf, z))
+
+
+def _compute_effective_truez(
+    z: Any,
+    bins_returned: Mapping[int, Any],
+) -> dict[int, dict[str, float | None]]:
+    """Compute true-redshift summary statistics for tomographic bins.
+
+    For each returned bin distribution ``n_i(z)``, this function computes a set
+    of summary statistics describing its location, width, and shape in true
+    redshift space.
+
+    The input distributions may be normalized or unnormalized; all statistics
+    are computed from the normalized shape.
+
+    The following quantities are computed per bin:
+        - Mean (z_mean)
+        - Median (z_median)
+        - Mode (z_mode)
+        - Central 68% interval (z_lo_68, z_hi_68)
+        - Central 95% interval (z_lo_95, z_hi_95)
+        - Additional quantiles (z_q05, z_q25, z_q75, z_q95)
+
+    These summaries provide a probabilistic description of each bin in true
+    redshift space, complementing the imposed bin edges defined in photo-z
+    space.
+
+    Args:
+        z: 1D array-like representing the true-redshift grid shared by all bins.
+        bins_returned: Mapping from bin index to arrays representing the
+            corresponding bin distributions evaluated on ``z``.
+
+    Returns:
+        Dictionary mapping each bin index to a dictionary of summary statistics.
+        If a bin has zero total weight, all summary values are set to ``None``.
+
+    Notes:
+        These statistics describe the effective support of each bin in true-z.
+        Due to photo-z scatter and bias, bins are generally overlapping and do
+        not correspond to sharp intervals in true redshift space.
+    """
+    z_arr = np.asarray(z, dtype=float)
+
+    out: dict[int, dict[str, float | None]] = {}
+
+    for i, n_bin in bins_returned.items():
+        pdf = np.asarray(n_bin, dtype=float)
+
+        area = float(np.trapezoid(pdf, z_arr))
+
+        if area <= 0.0:
+            out[int(i)] = {
+                "z_mean": None,
+                "z_median": None,
+                "z_mode": None,
+                "z_lo_68": None,
+                "z_hi_68": None,
+                "z_lo_95": None,
+                "z_hi_95": None,
+                "z_q05": None,
+                "z_q25": None,
+                "z_q75": None,
+                "z_q95": None,
+            }
+            continue
+
+        pdf_norm = pdf / area
+
+        z_mean = float(np.trapezoid(z_arr * pdf_norm, z_arr))
+        z_mode = float(z_arr[np.argmax(pdf_norm)])
+
+        out[int(i)] = {
+            "z_mean": z_mean,
+            "z_median": _weighted_quantile(z_arr, pdf_norm, 0.5),
+            "z_mode": z_mode,
+            "z_lo_68": _weighted_quantile(z_arr, pdf_norm, 0.16),
+            "z_hi_68": _weighted_quantile(z_arr, pdf_norm, 0.84),
+            "z_lo_95": _weighted_quantile(z_arr, pdf_norm, 0.025),
+            "z_hi_95": _weighted_quantile(z_arr, pdf_norm, 0.975),
+            "z_q05": _weighted_quantile(z_arr, pdf_norm, 0.05),
+            "z_q25": _weighted_quantile(z_arr, pdf_norm, 0.25),
+            "z_q75": _weighted_quantile(z_arr, pdf_norm, 0.75),
+            "z_q95": _weighted_quantile(z_arr, pdf_norm, 0.95),
+        }
+
+    return out
+
+
+def _metadata_description() -> dict[str, Any]:
+    """Return human-readable descriptions of metadata fields.
+
+    This provides a concise explanation of the meaning of each top-level
+    metadata field and key subfields. It is intended for inspection,
+    debugging, and reproducibility, and does not affect any computations.
+
+    Returns:
+        Dictionary mapping metadata keys to short textual descriptions.
+    """
+    return {
+        "kind": "Tomography type: 'photoz' (photo-z selected bins) or 'specz'.",
+        "grid": {
+            "z": "Redshift grid used for all distributions "
+            "(interpreted as true-z for photo-z bins)",
+            "z_min": "Minimum redshift of the grid.",
+            "z_max": "Maximum redshift of the grid.",
+            "n": "Number of grid points.",
+        },
+        "parent_nz": {
+            "values": "Parent redshift distribution evaluated on z.",
+            "norm": "Optional normalization of the parent distribution (depends on convention).",
+        },
+        "bins": {
+            "indices": "Indices of tomographic bins.",
+            "n_bins": "Total number of bins.",
+            "bin_edges": "Nominal bin edges (typically in photo-z space for photoz tomography).",
+            "bins_returned": "Per-bin distributions n_i(z) evaluated on the true-z grid.",
+            "bins_norms": "Optional per-bin normalization values.",
+            "frac_per_bin": "Optional fraction of galaxies per bin.",
+            "density_per_bin": "Optional number density per bin.",
+            "count_per_bin": "Optional galaxy counts per bin.",
+            "truez_summary": (
+                "Summary statistics of the true-redshift distribution in each bin "
+                "(mean, median, mode, and quantiles). These describe the "
+                "true-redshift distribution of each bin and are not hard edges."
+            ),
+        },
+        "inputs": "User-provided configuration used to generate the bins.",
+        "notes": "Optional user-provided annotations.",
+    }

--- a/tests/test_nz_tomo_photoz.py
+++ b/tests/test_nz_tomo_photoz.py
@@ -625,6 +625,106 @@ def test_build_photoz_bins_metadata_round_trip(z_nz, tmp_path):
     assert "bin_edges" in meta_str
     assert "bins_norms" in meta_str
 
+    assert "truez_summary" in meta["bins"]
+    assert set(meta["bins"]["truez_summary"].keys()) == {0, 1, 2}
+
     # Returned bins are unit-normalized when normalize_bins=True.
     for arr in bins.values():
         assert np.isclose(np.trapezoid(arr, x=z), 1.0, rtol=1e-6, atol=1e-8)
+
+
+def test_build_photoz_bins_metadata_includes_truez_summary(z_nz):
+    """Tests that photo-z metadata includes per-bin true-z summary statistics."""
+    z, nz = z_nz
+    edges = [0.0, 0.5, 1.0, 1.5]
+
+    bins, meta = build_photoz_bins(
+        z,
+        nz,
+        edges,
+        scatter_scale=0.05,
+        mean_offset=0.01,
+        normalize_bins=True,
+        include_metadata=True,
+    )
+
+    assert isinstance(bins, dict)
+    assert isinstance(meta, dict)
+
+    bins_meta = meta["bins"]
+    assert "truez_summary" in bins_meta
+
+    summary = bins_meta["truez_summary"]
+    assert isinstance(summary, dict)
+    assert set(summary.keys()) == {0, 1, 2}
+
+    expected_keys = {
+        "z_mean",
+        "z_median",
+        "z_mode",
+        "z_lo_68",
+        "z_hi_68",
+        "z_lo_95",
+        "z_hi_95",
+        "z_q05",
+        "z_q25",
+        "z_q75",
+        "z_q95",
+    }
+
+    for i in [0, 1, 2]:
+        assert set(summary[i].keys()) == expected_keys
+
+
+def test_build_photoz_bins_metadata_truez_summary_is_ordered(z_nz):
+    """Tests that true-z summary quantiles are finite and ordered per bin."""
+    z, nz = z_nz
+    edges = [0.0, 0.5, 1.0, 1.5]
+
+    _, meta = build_photoz_bins(
+        z,
+        nz,
+        edges,
+        scatter_scale=0.05,
+        mean_offset=0.01,
+        normalize_bins=True,
+        include_metadata=True,
+    )
+
+    summary = meta["bins"]["truez_summary"]
+
+    for stats in summary.values():
+        vals = [
+            stats["z_mean"],
+            stats["z_median"],
+            stats["z_mode"],
+            stats["z_lo_68"],
+            stats["z_hi_68"],
+            stats["z_lo_95"],
+            stats["z_hi_95"],
+            stats["z_q05"],
+            stats["z_q25"],
+            stats["z_q75"],
+            stats["z_q95"],
+        ]
+        assert all(v is not None for v in vals)
+        assert all(np.isfinite(v) for v in vals)
+
+        assert (
+            stats["z_lo_95"]
+            <= stats["z_lo_68"]
+            <= stats["z_median"]
+            <= stats["z_hi_68"]
+            <= stats["z_hi_95"]
+        )
+
+        assert (
+            stats["z_q05"]
+            <= stats["z_q25"]
+            <= stats["z_median"]
+            <= stats["z_q75"]
+            <= stats["z_q95"]
+        )
+
+        assert z[0] <= stats["z_mode"] <= z[-1]
+        assert z[0] <= stats["z_mean"] <= z[-1]

--- a/tests/test_utils_metadata.py
+++ b/tests/test_utils_metadata.py
@@ -6,7 +6,11 @@ from pathlib import Path
 
 import numpy as np
 
-from binny.utils.metadata import build_tomo_bins_metadata, save_metadata_txt
+from binny.utils.metadata import (
+    _weighted_quantile,
+    build_tomo_bins_metadata,
+    save_metadata_txt,
+)
 
 
 def test_build_tomo_bins_metadata_includes_optional_notes_and_casts_keys():
@@ -82,3 +86,90 @@ def test_save_metadata_txt_decimal_places_none_keeps_values_verbatim(
 
     lines = txt.splitlines()
     assert lines == ["x: 1.23456"]
+
+
+def test_build_tomo_bins_metadata_includes_truez_summary():
+    """Tests that truez_summary is present and contains expected keys."""
+    z = np.linspace(0.0, 2.0, 5)
+    parent = np.ones_like(z)
+    edges = np.array([0.0, 1.0, 2.0])
+
+    bins = {
+        0: np.exp(-((z - 0.5) ** 2) / 0.01),
+    }
+
+    meta = build_tomo_bins_metadata(
+        kind="photoz",
+        z=z,
+        parent_nz=parent,
+        bin_edges=edges,
+        bins_returned=bins,
+        inputs={},
+    )
+
+    summary = meta["bins"]["truez_summary"][0]
+
+    assert "z_mean" in summary
+    assert "z_median" in summary
+    assert "z_mode" in summary
+    assert summary["z_mean"] is not None
+
+
+def test_truez_summary_zero_weight_returns_none():
+    """Tests that zero-weight bins return None for all summary stats."""
+    z = np.linspace(0.0, 1.0, 5)
+    bins = {0: np.zeros_like(z)}
+
+    meta = build_tomo_bins_metadata(
+        kind="photoz",
+        z=z,
+        parent_nz=np.ones_like(z),
+        bin_edges=np.array([0.0, 1.0]),
+        bins_returned=bins,
+        inputs={},
+    )
+
+    summary = meta["bins"]["truez_summary"][0]
+
+    assert all(v is None for v in summary.values())
+
+
+def test_weighted_quantile_basic_behavior():
+    """Tests weighted quantile returns correct median for symmetric distribution."""
+    z = np.array([0.0, 1.0, 2.0])
+    pdf = np.array([0.0, 1.0, 0.0])
+
+    q50 = _weighted_quantile(z, pdf, 0.5)
+
+    assert q50 == 1.0
+
+
+def test_weighted_quantile_empty_returns_none():
+    """Tests weighted quantile returns None for empty input."""
+    z = np.array([])
+    pdf = np.array([])
+
+    assert _weighted_quantile(z, pdf, 0.5) is None
+
+
+def test_weighted_quantile_zero_area_returns_none():
+    """Tests weighted quantile returns None when pdf integrates to zero."""
+    z = np.array([0.0, 1.0])
+    pdf = np.array([0.0, 0.0])
+
+    assert _weighted_quantile(z, pdf, 0.5) is None
+
+
+def test_metadata_includes_description_block():
+    """Tests that metadata includes human-readable description."""
+    meta = build_tomo_bins_metadata(
+        kind="photoz",
+        z=np.array([0.0, 1.0]),
+        parent_nz=np.array([1.0, 1.0]),
+        bin_edges=np.array([0.0, 1.0]),
+        bins_returned={0: np.array([1.0, 1.0])},
+        inputs={},
+    )
+
+    assert "description" in meta
+    assert "truez_summary" in meta["description"]["bins"]


### PR DESCRIPTION
In this PR I have expanded the metadata to include the summary for true-z.
I have also added and extra metadata descriptiosn section to be returned to help user map out the returned values within the metadata dict.

closes #55 