### PR TITLE
Added survey preset discovery helpers

### DIFF
--- a/docs/examples/survey_presets.rst
+++ b/docs/examples/survey_presets.rst
@@ -13,6 +13,43 @@ metadata such as footprint or galaxy density.
 Using a YAML preset makes it easier to keep survey configurations
 consistent across forecasts, examples, and analyses.
 
+
+Discovering and loading presets
+-------------------------------
+
+Built-in survey presets can be discovered and loaded directly through
+``NZTomography``. The YAML files remain the single source of truth, while users
+can access them by survey name.
+
+.. code-block:: python
+
+   from binny import NZTomography
+
+
+   print(NZTomography.list_surveys())
+
+   cfg = NZTomography.load_survey_config("lsst")
+   NZTomography.show_survey_config("lsst")
+
+
+The returned ``cfg`` can be passed directly to ``build_bins``.
+
+.. code-block:: python
+
+   from binny import NZTomography
+
+
+   cfg = NZTomography.load_survey_config("lsst")
+
+   tomo = NZTomography()
+
+   source = tomo.build_bins(
+       cfg=cfg,
+       role="source",
+       year="1",
+   )
+
+
 LSST survey preset
 ------------------
 

--- a/docs/examples/survey_presets.rst
+++ b/docs/examples/survey_presets.rst
@@ -567,7 +567,7 @@ Binny also includes a DESI-inspired survey preset containing
 tabulated spectroscopic **LRG** and **ELG** lens redshift
 distributions.
 
-The default preset uses the legacy Dani redshift windows:
+The default preset uses the redshift windows from arXiv:2511.19194:
 :math:`0.4 \leq z \leq 1.0` for LRGs and
 :math:`0.6 \leq z \leq 1.5` for ELGs.
 

--- a/src/binny/api/nz_tomography.py
+++ b/src/binny/api/nz_tomography.py
@@ -34,11 +34,19 @@ from binny.nz.registry import nz_model as _nz_model
 from binny.nz_tomo._tomography_bins import TomographyBins
 from binny.nz_tomo.bin_stats import population_stats as _population_stats
 from binny.nz_tomo.bin_stats import shape_stats as _shape_stats
+from binny.surveys.survey_presets import (
+    list_survey_configs,
+    load_survey_config,
+    show_survey_config,
+)
 
 __all__ = [
     "NZTomography",
     "available_metric_kernels",
     "register_metric_kernel",
+    "list_survey_configs",
+    "load_survey_config",
+    "show_survey_config",
 ]
 
 
@@ -93,23 +101,45 @@ class NZTomography:
         return _available_nz_models()
 
     @staticmethod
-    def list_surveys() -> list[str]:
-        """List available shipped survey preset names.
+    def load_survey_config(survey: str) -> dict[str, Any]:
+        """Load a built-in survey configuration by survey name.
 
-        Survey presets are YAML configuration files shipped with the package,
-        following the naming convention ``<preset>_survey_specs.yaml``. This
-        method returns the available preset base names (without the suffix),
-        suitable for passing to :meth:`build_survey_bins`.
+        Args:
+            survey: Survey preset name, such as ``"lsst"``, ``"desi"``, or
+                ``"roman"``.
 
         Returns:
-            A sorted list of available survey preset base names.
+            Parsed survey configuration dictionary.
         """
-        presets: list[str] = []
-        for name in cu.list_configs():
-            s = str(name)
-            if s.endswith("_survey_specs.yaml"):
-                presets.append(s.removesuffix("_survey_specs.yaml"))
-        return sorted(set(presets))
+        return load_survey_config(survey)
+
+    @staticmethod
+    def show_survey_config(
+        survey: str,
+        *,
+        print_output: bool = True,
+    ) -> str:
+        """Show a built-in survey configuration as YAML text.
+
+        Args:
+            survey: Survey preset name, such as ``"lsst"``, ``"desi"``, or
+                ``"roman"``.
+            print_output: Whether to print the YAML text before returning it.
+
+        Returns:
+            The selected survey configuration formatted as YAML.
+        """
+        return show_survey_config(survey, print_output=print_output)
+
+    @staticmethod
+    def list_surveys() -> list[str]:
+        """List available built-in survey preset names.
+
+        Returns:
+            A sorted list of available survey preset names, such as ``"lsst"``,
+            ``"desi"``, or ``"roman"``.
+        """
+        return list_survey_configs()
 
     @property
     def z(self) -> np.ndarray:

--- a/src/binny/surveys/config_utils.py
+++ b/src/binny/surveys/config_utils.py
@@ -83,6 +83,7 @@ from binny.nz.registry import nz_model
 __all__ = [
     "config_path",
     "list_configs",
+    "load_config",
 ]
 
 _CONFIG_PKG = "binny.surveys.configs"
@@ -668,3 +669,32 @@ def _builder_kwargs_from_spec(spec: Mapping[str, Any]) -> dict[str, Any]:
 
     kwargs.update(params)
     return kwargs
+
+
+def load_config(path: str | Path) -> Mapping[Any, Any]:
+    """Load a survey configuration from a YAML file.
+
+    Args:
+        path: Path to a YAML file, or the filename of a shipped Binny survey
+            configuration.
+
+    Returns:
+        Parsed survey configuration mapping.
+
+    Raises:
+        ValueError: If the YAML root is not a mapping or the config has no
+            tomography list.
+        FileNotFoundError: If ``path`` is neither an existing file nor a
+            shipped config filename.
+    """
+    p = Path(path)
+
+    if not p.exists():
+        p = config_path(str(path))
+
+    cfg = _load_yaml_mapping(p)
+
+    if "tomography" not in cfg:
+        raise ValueError("Config must contain a 'tomography' list.")
+
+    return cfg

--- a/src/binny/surveys/survey_presets.py
+++ b/src/binny/surveys/survey_presets.py
@@ -1,0 +1,67 @@
+"""Helpers for working with built-in Binny survey configurations.
+
+This module provides a small public interface for discovering, loading, and
+displaying the survey YAML files distributed with Binny. These helpers let users
+access survey presets such as LSST, DESI, or Roman by name, without needing to
+know where the YAML files live inside the installed package.
+
+The returned configurations use the same dictionary structure as the YAML files
+and can be passed directly to :class:`binny.NZTomography`.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+from binny.surveys.config_utils import list_configs, load_config
+
+
+def load_survey_config(survey: str) -> dict[str, Any]:
+    """Load a built-in survey configuration by survey name.
+
+    Args:
+        survey: Survey preset name, such as ``"lsst"``, ``"desi"``, or
+            ``"roman"``.
+
+    Returns:
+        Parsed survey configuration dictionary.
+    """
+    name = str(survey).strip().lower()
+    return dict(load_config(f"{name}_survey_specs.yaml"))
+
+
+def list_survey_configs() -> list[str]:
+    """List built-in survey configuration names."""
+    surveys = []
+
+    for filename in list_configs():
+        if filename.endswith("_survey_specs.yaml"):
+            surveys.append(filename.removesuffix("_survey_specs.yaml"))
+
+    return sorted(set(surveys))
+
+
+def show_survey_config(
+    survey: str,
+    *,
+    print_output: bool = True,
+) -> str:
+    """Show a built-in survey configuration as YAML text.
+
+    Args:
+        survey: Survey preset name, such as ``"lsst"``, ``"desi"``, or
+            ``"roman"``.
+        print_output: Whether to print the YAML text before returning it.
+
+    Returns:
+        The selected survey configuration formatted as YAML.
+    """
+    cfg = load_survey_config(survey)
+    text = yaml.safe_dump(cfg, sort_keys=False)
+
+    if print_output:
+        print(text)
+
+    return text

--- a/tests/test_api_nz_tomography.py
+++ b/tests/test_api_nz_tomography.py
@@ -554,15 +554,28 @@ def test_list_nz_models_delegates(monkeypatch):
     assert NZTomography.list_nz_models() == ["a", "b"]
 
 
-def test_list_survey_presets_filters_suffix(monkeypatch):
-    """Tests that list_survey_presets filters out non-survey configs."""
+def test_list_survey_presets_delegates(monkeypatch):
+    """Tests that list_surveys delegates to the survey preset helper."""
     monkeypatch.setattr(
-        cu,
-        "list_configs",
-        lambda: ["lsst_survey_specs.yaml", "README.txt", "hsc_survey_specs.yaml", "foo.yaml"],
+        "binny.api.nz_tomography.list_survey_configs",
+        lambda: ["hsc", "lsst"],
         raising=True,
     )
+
     assert NZTomography.list_surveys() == ["hsc", "lsst"]
+
+
+def test_module_exports_survey_config_helpers():
+    """Tests that survey config helpers are importable from the public API module."""
+    from binny.api.nz_tomography import (
+        list_survey_configs,
+        load_survey_config,
+        show_survey_config,
+    )
+
+    assert callable(list_survey_configs)
+    assert callable(load_survey_config)
+    assert callable(show_survey_config)
 
 
 def test_registry_is_callable():
@@ -1034,3 +1047,75 @@ def test_between_sample_stats_delegates_to_between_sample_metrics(monkeypatch):
     assert calls["pearson"]["bins_a"] == t0.bins
     assert calls["pearson"]["bins_b"] == t1.bins
     assert calls["pearson"]["kw"] == {"clip": True}
+
+
+def test_load_survey_config_delegates(monkeypatch):
+    """Tests that NZTomography.load_survey_config delegates to the survey preset helper."""
+    called = {"survey": None}
+
+    def fake_load_survey_config(survey):
+        called["survey"] = survey
+        return {"name": survey, "tomography": []}
+
+    monkeypatch.setattr(
+        "binny.api.nz_tomography.load_survey_config",
+        fake_load_survey_config,
+        raising=True,
+    )
+
+    out = NZTomography.load_survey_config("lsst")
+
+    assert out == {"name": "lsst", "tomography": []}
+    assert called["survey"] == "lsst"
+
+
+def test_show_survey_config_delegates(monkeypatch):
+    """Tests that NZTomography.show_survey_config delegates to the survey preset helper."""
+    called = {"survey": None, "print_output": None}
+
+    def fake_show_survey_config(survey, *, print_output=True):
+        called["survey"] = survey
+        called["print_output"] = print_output
+        return "name: lsst\n"
+
+    monkeypatch.setattr(
+        "binny.api.nz_tomography.show_survey_config",
+        fake_show_survey_config,
+        raising=True,
+    )
+
+    out = NZTomography.show_survey_config("lsst", print_output=False)
+
+    assert out == "name: lsst\n"
+    assert called == {"survey": "lsst", "print_output": False}
+
+
+def test_list_surveys_matches_list_survey_configs(monkeypatch):
+    """Tests that list_surveys exposes the same values as list_survey_configs."""
+    monkeypatch.setattr(
+        "binny.api.nz_tomography.list_survey_configs",
+        lambda: ["desi", "lsst", "roman"],
+        raising=True,
+    )
+
+    assert NZTomography.list_surveys() == ["desi", "lsst", "roman"]
+
+
+def test_module_all_exports_survey_config_helpers():
+    """Tests that survey config helpers are included in __all__."""
+    from binny.api import nz_tomography
+
+    assert "list_survey_configs" in nz_tomography.__all__
+    assert "load_survey_config" in nz_tomography.__all__
+    assert "show_survey_config" in nz_tomography.__all__
+
+
+@pytest.mark.parametrize("survey", ["lsst", "desi", "roman"])
+def test_builtin_survey_configs_can_be_loaded(survey):
+    """Tests that representative built-in survey configs can be loaded."""
+    cfg = NZTomography.load_survey_config(survey)
+
+    assert cfg["name"] == survey
+    assert "tomography" in cfg
+    assert isinstance(cfg["tomography"], list)
+    assert len(cfg["tomography"]) > 0

--- a/tests/test_surveys_config_utils.py
+++ b/tests/test_surveys_config_utils.py
@@ -12,6 +12,7 @@ import yaml
 
 from binny.surveys.config_utils import (
     _build_parent_nz,
+    _builder_kwargs_from_spec,
     _extract_survey_meta,
     _extract_z_grid,
     _iter_tomography_entries,
@@ -26,6 +27,7 @@ from binny.surveys.config_utils import (
     _tabulated_params_from_config,
     config_path,
     list_configs,
+    load_config,
 )
 
 
@@ -546,3 +548,179 @@ def test_parse_entry_accepts_tabulated_source_block() -> None:
     assert spec["nz"]["model"] == "tabulated"
     assert spec["nz"]["source"]["path"] == "desi_lrg_nz.txt"
     assert np.allclose(spec["bins"]["edges"], [0.4, 1.0])
+
+
+def test_load_config_loads_yaml_file(tmp_path) -> None:
+    """Tests that load_config loads a YAML config from a file path."""
+
+    cfg = {
+        "name": "x",
+        "tomography": [
+            {
+                "role": "source",
+                "kind": "photoz",
+                "nz": {"model": "smail", "params": {}},
+                "bins": {"scheme": "equidistant", "n_bins": 2},
+            }
+        ],
+    }
+
+    p = tmp_path / "cfg.yaml"
+    p.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+    out = load_config(p)
+
+    assert isinstance(out, Mapping)
+    assert out["name"] == "x"
+    assert "tomography" in out
+
+
+def test_load_config_rejects_missing_tomography(tmp_path) -> None:
+    """Tests that load_config rejects configs without tomography."""
+
+    p = tmp_path / "cfg.yaml"
+    p.write_text(yaml.safe_dump({"name": "x"}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must contain a 'tomography' list"):
+        load_config(p)
+
+
+def test_select_entries_filters_by_scenario() -> None:
+    """Tests that _select_entries can distinguish scenarios."""
+    entries = [
+        {"role": "source", "scenario": "hls_optimistic"},
+        {"role": "source", "scenario": "hls_conservative"},
+    ]
+
+    sel = _select_entries(
+        entries,
+        role="source",
+        scenario="hls_optimistic",
+    )
+
+    assert len(sel) == 1
+    assert sel[0]["scenario"] == "hls_optimistic"
+
+
+def test_select_entries_filters_by_year_scenario_and_sample() -> None:
+    """Tests that _select_entries matches all provided selectors."""
+    entries = [
+        {"role": "lens", "year": "1", "scenario": "hls", "sample": "wide"},
+        {"role": "lens", "year": "1", "scenario": "wide", "sample": "wide"},
+        {"role": "lens", "year": "10", "scenario": "hls", "sample": "wide"},
+    ]
+
+    sel = _select_entries(
+        entries,
+        role="lens",
+        year="1",
+        scenario="hls",
+        sample="wide",
+    )
+
+    assert len(sel) == 1
+    assert sel[0]["year"] == "1"
+    assert sel[0]["scenario"] == "hls"
+    assert sel[0]["sample"] == "wide"
+
+
+def test_parse_bins_with_scheme_and_range() -> None:
+    """Tests that _parse_bins preserves scheme bin ranges."""
+    bins = _parse_bins(
+        {
+            "scheme": "equidistant",
+            "n_bins": 3,
+            "range": [0.2, 1.4],
+        }
+    )
+
+    assert bins["scheme"] == "equidistant"
+    assert bins["n_bins"] == 3
+    assert bins["range"] == (0.2, 1.4)
+
+
+def test_parse_bins_rejects_missing_n_bins() -> None:
+    """Tests that _parse_bins requires n_bins for scheme-based bins."""
+    with pytest.raises(ValueError, match="bins.n_bins is required"):
+        _parse_bins({"scheme": "equidistant"})
+
+
+def test_parse_bins_rejects_missing_edges_or_scheme() -> None:
+    """Tests that _parse_bins requires either edges or scheme."""
+    with pytest.raises(ValueError, match="must provide either 'edges' or 'scheme'"):
+        _parse_bins({})
+
+
+def test_builder_kwargs_from_spec_uses_edges() -> None:
+    """Tests that _builder_kwargs_from_spec converts explicit edges."""
+    spec = {
+        "bins": {"edges": np.array([0.0, 0.5, 1.0])},
+        "uncertainties": {"sigma_z": 0.05},
+    }
+
+    kwargs = _builder_kwargs_from_spec(spec)
+
+    assert np.allclose(kwargs["bin_edges"], [0.0, 0.5, 1.0])
+    assert kwargs["binning_scheme"] is None
+    assert kwargs["n_bins"] is None
+    assert kwargs["sigma_z"] == pytest.approx(0.05)
+
+
+def test_builder_kwargs_from_spec_uses_scheme_and_range() -> None:
+    """Tests that _builder_kwargs_from_spec converts scheme bins."""
+
+    spec = {
+        "bins": {
+            "scheme": "equidistant",
+            "n_bins": 4,
+            "range": (0.2, 1.2),
+        },
+        "uncertainties": {"scatter_scale": 0.03},
+    }
+
+    kwargs = _builder_kwargs_from_spec(spec)
+
+    assert kwargs["bin_edges"] is None
+    assert kwargs["binning_scheme"] == "equidistant"
+    assert kwargs["n_bins"] == 4
+    assert kwargs["bin_range"] == (0.2, 1.2)
+    assert kwargs["scatter_scale"] == pytest.approx(0.03)
+
+
+def test_builder_kwargs_from_spec_preserves_explicit_bin_range_uncertainty() -> None:
+    """Tests that uncertainties can explicitly override bin_range."""
+
+    spec = {
+        "bins": {
+            "scheme": "equidistant",
+            "n_bins": 4,
+            "range": (0.2, 1.2),
+        },
+        "uncertainties": {"bin_range": (0.3, 1.1)},
+    }
+
+    kwargs = _builder_kwargs_from_spec(spec)
+
+    assert kwargs["bin_range"] == (0.3, 1.1)
+
+
+def test_survey_meta_preserves_scenario_and_survey_meta(
+    minimal_cfg: Mapping[str, Any],
+) -> None:
+    """Tests that _survey_meta includes scenario and top-level metadata."""
+    meta = _survey_meta(
+        cfg=minimal_cfg,
+        resolved_key="k",
+        role="lens",
+        year="1",
+        scenario="test_scenario",
+        sample="samplename",
+    )
+
+    assert meta["survey"] == "test"
+    assert meta["key"] == "k"
+    assert meta["role"] == "lens"
+    assert meta["year"] == "1"
+    assert meta["scenario"] == "test_scenario"
+    assert meta["sample"] == "samplename"
+    assert meta["survey_meta"] == {"a": 1}

--- a/tests/test_surveys_survey_presets.py
+++ b/tests/test_surveys_survey_presets.py
@@ -1,0 +1,211 @@
+"""Unit tests for ``binny.surveys.survey_presets``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+import yaml
+
+from binny.surveys import survey_presets
+from binny.surveys.survey_presets import (
+    list_survey_configs,
+    load_survey_config,
+    show_survey_config,
+)
+
+
+def test_load_survey_config_normalizes_name(monkeypatch) -> None:
+    """Tests that load_survey_config normalizes survey names."""
+    called = {"path": None}
+
+    def fake_load_config(path: str) -> dict[str, Any]:
+        called["path"] = path
+        return {"name": "lsst", "tomography": []}
+
+    monkeypatch.setattr(
+        survey_presets,
+        "load_config",
+        fake_load_config,
+        raising=True,
+    )
+
+    cfg = load_survey_config(" LSST ")
+
+    assert cfg == {"name": "lsst", "tomography": []}
+    assert called["path"] == "lsst_survey_specs.yaml"
+
+
+def test_load_survey_config_returns_plain_dict(monkeypatch) -> None:
+    """Tests that load_survey_config returns a plain dictionary."""
+
+    class MappingLike(dict):
+        """Small dict subclass used to check dict conversion."""
+
+    monkeypatch.setattr(
+        survey_presets,
+        "load_config",
+        lambda path: MappingLike({"name": "desi", "tomography": []}),
+        raising=True,
+    )
+
+    cfg = load_survey_config("desi")
+
+    assert type(cfg) is dict
+    assert cfg["name"] == "desi"
+    assert cfg["tomography"] == []
+
+
+def test_load_survey_config_propagates_missing_config(monkeypatch) -> None:
+    """Tests that load_survey_config propagates missing-config errors."""
+
+    def fake_load_config(path: str) -> dict[str, Any]:
+        raise FileNotFoundError("missing config")
+
+    monkeypatch.setattr(
+        survey_presets,
+        "load_config",
+        fake_load_config,
+        raising=True,
+    )
+
+    with pytest.raises(FileNotFoundError, match="missing config"):
+        load_survey_config("not-a-survey")
+
+
+def test_list_survey_configs_filters_suffix(monkeypatch) -> None:
+    """Tests that list_survey_configs filters survey config filenames."""
+    monkeypatch.setattr(
+        survey_presets,
+        "list_configs",
+        lambda: [
+            "lsst_survey_specs.yaml",
+            "README.txt",
+            "hsc_survey_specs.yaml",
+            "foo.yaml",
+            "roman_survey_specs.yml",
+            "desi_survey_specs.yaml",
+        ],
+        raising=True,
+    )
+
+    assert list_survey_configs() == ["desi", "hsc", "lsst"]
+
+
+def test_list_survey_configs_returns_unique_sorted_names(monkeypatch) -> None:
+    """Tests that list_survey_configs returns sorted unique survey names."""
+    monkeypatch.setattr(
+        survey_presets,
+        "list_configs",
+        lambda: [
+            "roman_survey_specs.yaml",
+            "lsst_survey_specs.yaml",
+            "roman_survey_specs.yaml",
+            "desi_survey_specs.yaml",
+        ],
+        raising=True,
+    )
+
+    assert list_survey_configs() == ["desi", "lsst", "roman"]
+
+
+def test_list_survey_configs_returns_empty_list_when_no_presets(monkeypatch) -> None:
+    """Tests that list_survey_configs returns an empty list when no presets exist."""
+    monkeypatch.setattr(
+        survey_presets,
+        "list_configs",
+        lambda: [
+            "README.txt",
+            "example.yaml",
+            "example_survey_specs.yml",
+        ],
+        raising=True,
+    )
+
+    assert list_survey_configs() == []
+
+
+def test_show_survey_config_returns_yaml_text(monkeypatch) -> None:
+    """Tests that show_survey_config returns YAML text."""
+    cfg = {
+        "name": "lsst",
+        "tomography": [
+            {
+                "role": "source",
+                "kind": "photoz",
+            }
+        ],
+    }
+
+    monkeypatch.setattr(
+        survey_presets,
+        "load_survey_config",
+        lambda survey: cfg,
+        raising=True,
+    )
+
+    text = show_survey_config("lsst", print_output=False)
+
+    assert isinstance(text, str)
+    assert yaml.safe_load(text) == cfg
+    assert "name: lsst" in text
+    assert "tomography:" in text
+
+
+def test_show_survey_config_does_not_print_when_disabled(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Tests that show_survey_config can suppress printing."""
+    monkeypatch.setattr(
+        survey_presets,
+        "load_survey_config",
+        lambda survey: {"name": "lsst", "tomography": []},
+        raising=True,
+    )
+
+    text = show_survey_config("lsst", print_output=False)
+    captured = capsys.readouterr()
+
+    assert text
+    assert captured.out == ""
+
+
+def test_show_survey_config_prints_by_default(
+    monkeypatch,
+    capsys,
+) -> None:
+    """Tests that show_survey_config prints YAML by default."""
+    monkeypatch.setattr(
+        survey_presets,
+        "load_survey_config",
+        lambda survey: {"name": "roman", "tomography": []},
+        raising=True,
+    )
+
+    text = show_survey_config("roman")
+    captured = capsys.readouterr()
+
+    assert captured.out == text + "\n"
+    assert "name: roman" in captured.out
+    assert "tomography:" in captured.out
+
+
+def test_show_survey_config_forwards_survey_name(monkeypatch) -> None:
+    """Tests that show_survey_config forwards the survey name to the loader."""
+    called = {"survey": None}
+
+    def fake_load_survey_config(survey: str) -> dict[str, Any]:
+        called["survey"] = survey
+        return {"name": "desi", "tomography": []}
+
+    monkeypatch.setattr(
+        survey_presets,
+        "load_survey_config",
+        fake_load_survey_config,
+        raising=True,
+    )
+
+    show_survey_config("DESI", print_output=False)
+
+    assert called["survey"] == "DESI"


### PR DESCRIPTION
this PR adds a small public API for built-in survey presets.

YAML files remain the single source of truth, but users can now list, load, and print presets without knowing internal file paths.

## Changes

- Add `list_survey_configs`, `load_survey_config`, and `show_survey_config`
- Expose preset helpers through `NZTomography`
- Add tests
- Update survey preset docs

This closes #61 