### PR TITLE
Add tabulated comoving population statistics

### DIFF
--- a/src/binny/api/nz_tomography.py
+++ b/src/binny/api/nz_tomography.py
@@ -485,7 +485,76 @@ class NZTomography:
         meta = self._state.get("tomo_meta")
         if meta is None:
             raise ValueError("No tomo metadata cached. Rebuild with include_tomo_metadata=True.")
+        spec = self._state.get("tomo_spec", {})
+        sample_properties = spec.get("sample_properties", {})
+        number_density = sample_properties.get("number_density", {})
+
+        if (
+            number_density.get("model") == "tabulated_comoving"
+            and "total_count_per_bin" not in kwargs
+            and "volume_per_bin" not in kwargs
+        ):
+            extra = self._tabulated_comoving_population_stats(number_density)
+            kwargs = {**extra, **kwargs}
+
         return _population_stats(bins=self._state["bins"], metadata=meta, **kwargs)
+
+    def _tabulated_comoving_population_stats(
+        self,
+        number_density: Mapping[str, Any],
+    ) -> dict[str, dict[int, float]]:
+        """Return count and volume summaries for tabulated comoving densities."""
+        self._require_state()
+
+        state = self._state
+
+        if state is None:
+            raise ValueError("No cached entry. Call build_bins(...) first.")
+
+        spec = state["tomo_spec"]
+        source = spec.get("nz", {}).get("source", {})
+
+        count_col = number_density.get("total_count_col")
+        volume_col = number_density.get("volume_col")
+        z_col = source.get("z_col", 0)
+
+        if count_col is None or volume_col is None:
+            raise ValueError(
+                "tabulated_comoving number_density requires 'total_count_col' and 'volume_col'."
+            )
+
+        path = source.get("path")
+        skiprows = source.get("skiprows", 0)
+
+        if path is None:
+            raise ValueError("tabulated_comoving population statistics require nz.source.path.")
+
+        data = np.loadtxt(cu.data_path(path), skiprows=int(skiprows))
+
+        z_table = np.asarray(data[:, int(z_col)], dtype=float)
+        counts = np.asarray(data[:, int(count_col)], dtype=float)
+        volumes = np.asarray(data[:, int(volume_col)], dtype=float)
+
+        edges = np.asarray(spec["bins"]["edges"], dtype=float)
+
+        total_count_per_bin: dict[int, float] = {}
+        volume_per_bin: dict[int, float] = {}
+
+        for bin_index in range(len(edges) - 1):
+            z_min = float(edges[bin_index])
+            z_max = float(edges[bin_index + 1])
+
+            mask = (z_table >= z_min) & (z_table < z_max)
+            if bin_index == len(edges) - 2:
+                mask = (z_table >= z_min) & (z_table <= z_max)
+
+            total_count_per_bin[bin_index] = float(np.sum(counts[mask]))
+            volume_per_bin[bin_index] = float(np.sum(volumes[mask]))
+
+        return {
+            "total_count_per_bin": total_count_per_bin,
+            "volume_per_bin": volume_per_bin,
+        }
 
     def cross_bin_stats(
         self,

--- a/src/binny/nz_tomo/bin_stats.py
+++ b/src/binny/nz_tomo/bin_stats.py
@@ -29,15 +29,16 @@ __all__ = [
     "bin_moments",
     "bin_quantiles",
     "bin_centers",
+    "comoving_density_per_bin",
+    "galaxy_fraction_per_bin",
+    "galaxy_count_per_bin",
+    "galaxy_density_per_bin",
     "in_range_fraction",
     "in_range_fraction_per_bin",
     "peak_flags",
     "peak_flags_per_bin",
-    "galaxy_fraction_per_bin",
-    "galaxy_count_per_bin",
-    "galaxy_density_per_bin",
-    "shape_stats",
     "population_stats",
+    "shape_stats",
 ]
 
 
@@ -593,6 +594,23 @@ def shape_stats(
     return round_floats(out, decimal_places)
 
 
+def comoving_density_per_bin(
+    total_count_per_bin: Mapping[int, float],
+    volume_per_bin: Mapping[int, float],
+) -> dict[int, float]:
+    """Compute per-bin comoving number densities from counts and volumes."""
+    out: dict[int, float] = {}
+
+    for idx, count in total_count_per_bin.items():
+        volume = float(volume_per_bin[int(idx)])
+        if volume <= 0.0:
+            raise ValueError(f"volume_per_bin[{idx}] must be positive.")
+
+        out[int(idx)] = float(count) / volume
+
+    return out
+
+
 def population_stats(
     bins: Mapping[int, Any],
     metadata: Mapping[str, Any],
@@ -602,50 +620,61 @@ def population_stats(
     normalize_frac: bool = True,
     rtol: float = 1e-2,
     atol: float = 1e-3,
+    total_count_per_bin: Mapping[int, float] | None = None,
+    volume_per_bin: Mapping[int, float] | None = None,
     decimal_places: int | None = 2,
 ) -> dict[str, Any]:
     """Compute population / normalization statistics for tomographic bins.
 
-    This function computes quantities that depend on *relative bin populations*,
-    using metadata produced by Binny's tomo builders (photo-z / spec-z).
+    This function computes quantities that depend on relative bin populations,
+    using metadata produced by Binny's tomo builders.
 
-    The primary input is ``metadata["frac_per_bin"]`` (mapping bin index -> fraction).
-    Fractions are always checked against the bin indices present in ``bins``.
+    The primary input is ``metadata["frac_per_bin"]`` (mapping bin index to
+    fraction). Fractions are checked against the bin indices present in
+    ``bins``.
 
-    Optional survey-level allocation:
+    Optional allocations:
 
-    - If ``density_total`` (gal/arcmin^2) is provided, return per-bin allocated
-      surface densities.
-    - If ``survey_area`` (arcmin^2) is also provided, return per-bin effective counts.
+    - If ``density_total`` is provided, return per-bin allocated surface
+      densities in galaxies per square arcminute.
+    - If ``survey_area`` is also provided, return effective counts using the
+      surface density and survey area in square arcminutes.
+    - If ``total_count_per_bin`` and ``volume_per_bin`` are provided, return
+      per-bin comoving densities computed as count divided by volume.
 
     Args:
         bins: Mapping from bin index to bin curves.
         metadata: Tomography metadata containing ``"frac_per_bin"``.
-        density_total: Optional total effective surface density (gal/arcmin^2).
-        survey_area: Optional survey area (arcmin^2). Requires ``density_total``.
+        density_total: Optional total effective surface density in
+            galaxies per square arcminute.
+        survey_area: Optional survey area in square arcminutes. Requires
+            ``density_total``.
         normalize_frac: If True, renormalize metadata fractions to sum to 1.
-            If False, require they sum to 1 within (rtol, atol).
-        rtol: Relative tolerance for sum-to-one checks when normalize_frac=False.
-        atol: Absolute tolerance for sum-to-one checks when normalize_frac=False.
+            If False, require they sum to 1 within ``rtol`` and ``atol``.
+        rtol: Relative tolerance for sum-to-one checks when
+            ``normalize_frac=False``.
+        atol: Absolute tolerance for sum-to-one checks when
+            ``normalize_frac=False``.
+        total_count_per_bin: Optional mapping from bin index to total galaxy
+            count in that bin.
+        volume_per_bin: Optional mapping from bin index to comoving volume in
+            that bin.
         decimal_places: Rounding precision for returned values.
 
     Returns:
-        Mapping with keys:
-
-        - ``"fractions"``: {bin_idx: fraction}
-
-        And optionally:
-
-        - ``"density_total"``: float
-        - ``"density_per_bin"``: {bin_idx: gal/arcmin^2}
-        - ``"survey_area"``: float
-        - ``"count_per_bin"``: {bin_idx: effective count}
+        Mapping with key ``"fractions"`` and, when requested, surface-density
+        fields, count fields, or comoving-density fields. Comoving densities are
+        returned under ``"density_per_bin"`` with ``"density_unit"`` set to
+        ``"h^3 Mpc^-3"``.
 
     Raises:
         ValueError: If bins is empty.
         ValueError: If metadata does not contain ``"frac_per_bin"``.
         ValueError: If metadata fractions are missing any bin index.
-        ValueError: If survey_area is provided without density_total.
+        ValueError: If ``survey_area`` is provided without ``density_total``.
+        ValueError: If only one of ``total_count_per_bin`` and
+            ``volume_per_bin`` is provided.
+        ValueError: If any requested comoving volume is non-positive.
         ValueError: If fractions cannot be normalized or validated.
     """
     indices = sorted(int(i) for i in bins.keys())
@@ -674,6 +703,18 @@ def population_stats(
         frac = {i: f / s for i, f in frac.items()}
 
     out: dict[str, Any] = {"fractions": frac}
+
+    if total_count_per_bin is not None or volume_per_bin is not None:
+        if total_count_per_bin is None or volume_per_bin is None:
+            raise ValueError("total_count_per_bin and volume_per_bin must be provided together.")
+
+        counts = {int(i): float(total_count_per_bin[i]) for i in indices}
+        volumes = {int(i): float(volume_per_bin[i]) for i in indices}
+
+        out["total_count_per_bin"] = counts
+        out["volume_per_bin"] = volumes
+        out["density_per_bin"] = comoving_density_per_bin(counts, volumes)
+        out["density_unit"] = "h^3 Mpc^-3"
 
     if density_total is not None:
         density_per_bin_all = galaxy_density_per_bin(

--- a/tests/test_nz_tomo_bin_stats.py
+++ b/tests/test_nz_tomo_bin_stats.py
@@ -9,6 +9,7 @@ from binny.nz_tomo.bin_stats import (
     bin_centers,
     bin_moments,
     bin_quantiles,
+    comoving_density_per_bin,
     galaxy_count_per_bin,
     galaxy_density_per_bin,
     galaxy_fraction_per_bin,
@@ -773,3 +774,124 @@ def test_population_stats_density_helper_output_is_restricted_to_bins() -> None:
     out = population_stats(bins, meta, density_total=100.0)
 
     assert set(out["density_per_bin"]) == {0, 1}
+
+
+def test_comoving_density_per_bin_returns_count_over_volume() -> None:
+    """Tests that comoving density is computed as count divided by volume."""
+    counts = {0: 50.0, 1: 120.0}
+    volumes = {0: 1000.0, 1: 2000.0}
+
+    out = comoving_density_per_bin(counts, volumes)
+
+    assert out[0] == pytest.approx(0.05)
+    assert out[1] == pytest.approx(0.06)
+
+
+def test_comoving_density_per_bin_rejects_nonpositive_volume() -> None:
+    """Tests that comoving density requires positive volumes."""
+    counts = {0: 50.0}
+    volumes = {0: 0.0}
+
+    with pytest.raises(ValueError, match=r"volume_per_bin\[0\] must be positive"):
+        comoving_density_per_bin(counts, volumes)
+
+
+def test_population_stats_accepts_count_and_volume_per_bin() -> None:
+    """Tests population stats with externally supplied counts and volumes."""
+    bins = _dummy_bins(2)
+    meta = {"frac_per_bin": {0: 1.0, 1: 3.0}}
+
+    out = population_stats(
+        bins,
+        meta,
+        total_count_per_bin={0: 50.0, 1: 120.0},
+        volume_per_bin={0: 1000.0, 1: 2000.0},
+        decimal_places=None,
+    )
+
+    assert out["fractions"][0] == pytest.approx(0.25)
+    assert out["fractions"][1] == pytest.approx(0.75)
+
+    assert out["total_count_per_bin"][0] == pytest.approx(50.0)
+    assert out["total_count_per_bin"][1] == pytest.approx(120.0)
+
+    assert out["volume_per_bin"][0] == pytest.approx(1000.0)
+    assert out["volume_per_bin"][1] == pytest.approx(2000.0)
+
+    assert out["density_per_bin"][0] == pytest.approx(0.05)
+    assert out["density_per_bin"][1] == pytest.approx(0.06)
+    assert out["density_unit"] == "h^3 Mpc^-3"
+
+
+def test_population_stats_count_and_volume_inputs_must_be_paired() -> None:
+    """Tests that count and volume inputs must be supplied together."""
+    bins = _dummy_bins(2)
+    meta = {"frac_per_bin": {0: 1.0, 1: 1.0}}
+
+    with pytest.raises(
+        ValueError,
+        match="total_count_per_bin and volume_per_bin must be provided together",
+    ):
+        population_stats(
+            bins,
+            meta,
+            total_count_per_bin={0: 50.0, 1: 120.0},
+        )
+
+    with pytest.raises(
+        ValueError,
+        match="total_count_per_bin and volume_per_bin must be provided together",
+    ):
+        population_stats(
+            bins,
+            meta,
+            volume_per_bin={0: 1000.0, 1: 2000.0},
+        )
+
+
+def test_population_stats_count_volume_output_restricted_to_requested_bins() -> None:
+    """Tests that count, volume, and density outputs follow the requested bins."""
+    bins = _dummy_bins(2)
+    meta = {"frac_per_bin": {0: 1.0, 1: 1.0, 2: 1.0}}
+
+    out = population_stats(
+        bins,
+        meta,
+        total_count_per_bin={0: 50.0, 1: 120.0, 2: 999.0},
+        volume_per_bin={0: 1000.0, 1: 2000.0, 2: 9999.0},
+        decimal_places=None,
+    )
+
+    assert set(out["total_count_per_bin"]) == {0, 1}
+    assert set(out["volume_per_bin"]) == {0, 1}
+    assert set(out["density_per_bin"]) == {0, 1}
+
+
+def test_population_stats_count_volume_branch_rejects_bad_volume() -> None:
+    """Tests that population_stats propagates invalid volume checks."""
+    bins = _dummy_bins(1)
+    meta = {"frac_per_bin": {0: 1.0}}
+
+    with pytest.raises(ValueError, match=r"volume_per_bin\[0\] must be positive"):
+        population_stats(
+            bins,
+            meta,
+            total_count_per_bin={0: 50.0},
+            volume_per_bin={0: -1.0},
+            decimal_places=None,
+        )
+
+
+def test_tabulated_comoving_number_density_metadata_schema() -> None:
+    """Tests the generic tabulated-comoving number-density metadata schema."""
+    number_density = {
+        "model": "tabulated_comoving",
+        "n_gal_comoving_h3_mpc3_col": 3,
+        "total_count_col": 4,
+        "volume_col": 5,
+    }
+
+    assert number_density["model"] == "tabulated_comoving"
+    assert number_density["n_gal_comoving_h3_mpc3_col"] == 3
+    assert number_density["total_count_col"] == 4
+    assert number_density["volume_col"] == 5


### PR DESCRIPTION
## Summary

This PR extends Binny population statistics to support tabulated comoving density information for samples where per-bin counts and comoving volumes are available.

The main motivation is survey presets such as DESI SGC samples, where the input tables provide comoving number density, total counts, and volumes. The implementation keeps this generic and survey-agnostic.

## Changes

- Add support for per-bin comoving densities computed from total counts and volumes.
- Expose the new population-stat fields through the tomography API.
- Add tests for count/volume population statistics and validation behavior.

