### PR TITLE
Fix tabulated survey data loading for comoving population stats

### DIFF
--- a/src/binny/api/nz_tomography.py
+++ b/src/binny/api/nz_tomography.py
@@ -523,13 +523,10 @@ class NZTomography:
                 "tabulated_comoving number_density requires 'total_count_col' and 'volume_col'."
             )
 
-        path = source.get("path")
-        skiprows = source.get("skiprows", 0)
-
-        if path is None:
+        if source.get("path") is None:
             raise ValueError("tabulated_comoving population statistics require nz.source.path.")
 
-        data = np.loadtxt(cu.data_path(path), skiprows=int(skiprows))
+        data = cu._load_tabulated_source_table(source)
 
         z_table = np.asarray(data[:, int(z_col)], dtype=float)
         counts = np.asarray(data[:, int(count_col)], dtype=float)

--- a/src/binny/surveys/config_utils.py
+++ b/src/binny/surveys/config_utils.py
@@ -541,6 +541,25 @@ def _build_parent_nz(entry: Mapping[Any, Any], z: np.ndarray) -> np.ndarray:
     return nz_model(model, z, **model_params)
 
 
+def _load_tabulated_source_table(source: Mapping[Any, Any]) -> np.ndarray:
+    """Load a packaged or absolute tabulated survey data source."""
+    source = _require_mapping(source, what="tomography entry.nz.source")
+
+    try:
+        path = Path(source["path"])
+    except KeyError as e:
+        raise ValueError("tomography entry.nz.source must contain a 'path' field.") from e
+
+    if not path.is_absolute():
+        path = resources.files(_DATA_PKG) / str(path)
+
+    with resources.as_file(path) as real_path:
+        return np.loadtxt(
+            real_path,
+            skiprows=int(source.get("skiprows", 0)),
+        )
+
+
 def _tabulated_params_from_config(nz_cfg: Mapping[Any, Any]) -> dict[str, Any]:
     """Return tabulated n(z) inputs from inline arrays or a source file.
 
@@ -572,20 +591,7 @@ def _tabulated_params_from_config(nz_cfg: Mapping[Any, Any]) -> dict[str, Any]:
         return {}
 
     source = _require_mapping(source, what="tomography entry.nz.source")
-
-    try:
-        path = Path(source["path"])
-    except KeyError as e:
-        raise ValueError("tomography entry.nz.source must contain a 'path' field.") from e
-
-    if not path.is_absolute():
-        path = resources.files(_DATA_PKG) / str(path)
-
-    with resources.as_file(path) as real_path:
-        table = np.loadtxt(
-            real_path,
-            skiprows=int(source.get("skiprows", 0)),
-        )
+    table = _load_tabulated_source_table(source)
 
     z_col = int(source.get("z_col", 0))
     nz_col = int(source.get("nz_col", 1))


### PR DESCRIPTION
This PR fixes packaged survey-data loading for tabulated comoving population statistics.

The new `tabulated_comoving` population-stat path now reuses the same packaged-data loader logic already used by tabulated n(z) survey inputs, ensuring consistent handling of bundled survey files.

This was needed for survey presets such as DESI SGC samples, where comoving densities, counts, and volumes are read from bundled survey tables.

## Changes

- Add shared helper for loading packaged tabulated survey data.
- Reuse the shared loader in tabulated n(z) parsing.
- Reuse the same loader in tabulated comoving population statistics.



