### PR TITLE
Feature/combine samples

### DIFF
--- a/docs/examples/index.rst
+++ b/docs/examples/index.rst
@@ -30,6 +30,7 @@ workflows.
          bin_diagnostics
          survey_presets
          selections
+         sample_composition
 
    .. grid-item::
       :class: sd-text-center hero-logo

--- a/docs/examples/sample_composition.rst
+++ b/docs/examples/sample_composition.rst
@@ -1,0 +1,345 @@
+.. |logo| image:: ../_static/assets/logo.png
+   :alt: logo
+   :width: 32px
+
+|logo| Sample composition
+=========================
+
+Binny can combine several tomographic samples into one logical sample
+collection. This is useful when different galaxy samples should contribute to
+one parent redshift distribution, while still preserving sample-aware bin
+labels for downstream selections and data-vector construction.
+
+There are two common use cases:
+
+- physically adding samples together, for example when LRG and ELG should be
+  treated as one effective lens population;
+- keeping samples separate but using sample-aware labels, for example when a
+  data vector must distinguish ``("LRG", 0)`` from ``("ELG", 0)``.
+
+The first case uses ``combine_parent_nz`` or ``combine_tomography_bins``. The
+second case uses ``sample_bin_labels``, ``sample_bins``, and
+``sample_combinations``.
+
+This example uses the DESI survey preset and combines the DESI LRG and ELG
+lens samples.
+
+Combining DESI parent samples
+-----------------------------
+
+Parent-sample composition adds the parent redshift distributions. If samples are
+defined on different redshift grids, ``interpolate=True`` maps them onto a common
+grid before summing. By default, the first sample grid is used as the target
+grid unless ``z_target`` is provided explicitly.
+
+.. code-block:: python
+
+   from binny import NZTomography
+
+
+   lrg_tomo = NZTomography()
+   elg_tomo = NZTomography()
+
+   lrg = lrg_tomo.build_survey_bins(
+       "desi",
+       role="lens",
+       sample="lrg",
+       overrides={"bins": {"edges": [0.4, 0.6, 0.8, 1.0]}},
+   )
+
+   elg = elg_tomo.build_survey_bins(
+       "desi",
+       role="lens",
+       sample="elg",
+       overrides={"bins": {"edges": [0.6, 0.9, 1.2, 1.5]}},
+   )
+
+   z_combined, nz_combined = NZTomography.combine_parent_nz(
+       [
+           {"z": lrg.z, "nz": lrg.nz},
+           {"z": elg.z, "nz": elg.nz},
+       ],
+       interpolate=True,
+   )
+
+
+The returned arrays are plain NumPy arrays. This makes the combined parent
+distribution easy to inspect, plot, or pass into another custom binning step.
+
+Visualizing parent sample composition
+-------------------------------------
+
+The figure below compares the DESI LRG and ELG parent redshift distributions
+with their combined parent distribution.
+
+.. plot::
+   :include-source: False
+   :width: 850
+
+   import cmasher as cmr
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   from binny import NZTomography
+
+
+   lrg_tomo = NZTomography()
+   elg_tomo = NZTomography()
+
+   lrg = lrg_tomo.build_survey_bins(
+       "desi",
+       role="lens",
+       sample="lrg",
+       overrides={"bins": {"edges": [0.4, 0.6, 0.8, 1.0]}},
+   )
+
+   elg = elg_tomo.build_survey_bins(
+       "desi",
+       role="lens",
+       sample="elg",
+       overrides={"bins": {"edges": [0.6, 0.9, 1.2, 1.5]}},
+   )
+
+   z_combined, nz_combined = NZTomography.combine_parent_nz(
+       [
+           {"z": lrg.z, "nz": lrg.nz},
+           {"z": elg.z, "nz": elg.nz},
+       ],
+       interpolate=True,
+   )
+
+   colors = cmr.take_cmap_colors(
+       "viridis",
+       3,
+       cmap_range=(0.15, 0.85),
+       return_fmt="hex",
+   )
+
+   fig, ax = plt.subplots(figsize=(8.5, 4.8))
+
+   ax.fill_between(
+       lrg.z,
+       0.0,
+       lrg.nz,
+       color=colors[0],
+       alpha=0.45,
+       linewidth=0.0,
+       label="LRG parent",
+   )
+   ax.plot(lrg.z, lrg.nz, color="k", linewidth=1.8)
+
+   ax.fill_between(
+       elg.z,
+       0.0,
+       elg.nz,
+       color=colors[1],
+       alpha=0.45,
+       linewidth=0.0,
+       label="ELG parent",
+   )
+   ax.plot(elg.z, elg.nz, color="k", linewidth=1.8)
+
+   ax.plot(
+       z_combined,
+       nz_combined,
+       color=colors[2],
+       linewidth=3.0,
+       label="Combined parent",
+   )
+
+   ax.plot(z_combined, np.zeros_like(z_combined), color="k", linewidth=2.0)
+
+   ax.set_xlim(0.35, 1.55)
+   ax.set_xlabel("Redshift $z$")
+   ax.set_ylabel(r"Normalized $n(z)$")
+   ax.set_title("DESI parent sample composition")
+   ax.legend(frameon=False)
+
+   plt.tight_layout()
+
+
+Parent-level composition is useful for visual checks, but many analyses need the
+tomographic bins themselves. In that case, matching bin indices can be summed
+directly. This requires the samples to have the same bin keys. For example, bin
+``0`` in the combined sample is the sum of bin ``0`` from each input sample.
+
+Combining matching tomographic bins
+-----------------------------------
+
+If different samples use the same number of tomographic bins, their matching
+bin indices can also be added together.
+
+.. code-block:: python
+
+   combined = NZTomography.combine_tomography_bins(
+       [lrg, elg],
+       interpolate=True,
+   )
+
+
+Visualizing combined tomography
+-------------------------------
+
+The figure below shows the DESI LRG bins, DESI ELG bins, and the combined
+tomographic sample obtained by summing matching bin indices.
+
+.. plot::
+   :include-source: False
+   :width: 900
+
+   import cmasher as cmr
+   import matplotlib.pyplot as plt
+   import numpy as np
+
+   from binny import NZTomography
+
+
+   def plot_bins(ax, result, title):
+       z = result.z
+       bin_dict = result.bins
+       keys = sorted(bin_dict.keys())
+
+       colors = cmr.take_cmap_colors(
+           "viridis",
+           len(keys),
+           cmap_range=(0.1, 0.9),
+           return_fmt="hex",
+       )
+
+       for i, (color, key) in enumerate(zip(colors, keys, strict=True)):
+           curve = np.asarray(bin_dict[key], dtype=float)
+
+           ax.fill_between(
+               z,
+               0.0,
+               curve,
+               color=color,
+               alpha=0.65,
+               linewidth=0.0,
+               zorder=10 + i,
+           )
+
+           ax.plot(
+               z,
+               curve,
+               color="k",
+               linewidth=1.8,
+               zorder=20 + i,
+           )
+
+       ax.plot(z, np.zeros_like(z), color="k", linewidth=2.0, zorder=1000)
+
+       ax.set_title(title)
+       ax.set_xlabel("Redshift $z$")
+
+
+   lrg_tomo = NZTomography()
+   elg_tomo = NZTomography()
+
+   lrg = lrg_tomo.build_survey_bins(
+       "desi",
+       role="lens",
+       sample="lrg",
+       overrides={"bins": {"edges": [0.4, 0.6, 0.8, 1.0]}},
+   )
+
+   elg = elg_tomo.build_survey_bins(
+       "desi",
+       role="lens",
+       sample="elg",
+       overrides={"bins": {"edges": [0.6, 0.9, 1.2, 1.5]}},
+   )
+
+   combined = NZTomography.combine_tomography_bins(
+       [lrg, elg],
+       interpolate=True,
+   )
+
+   fig, axes = plt.subplots(
+       1,
+       3,
+       figsize=(13.5, 4.6),
+   )
+
+   plot_bins(axes[0], lrg, "DESI LRG bins")
+   plot_bins(axes[1], elg, "DESI ELG bins")
+   plot_bins(axes[2], combined, "Combined LRG + ELG bins")
+
+   for ax in axes:
+       ax.set_xlim(0.35, 1.55)
+
+   axes[0].set_ylabel(r"Normalized $n_i(z)$")
+
+   plt.suptitle("DESI sample-composed tomography", fontsize=16)
+
+   plt.tight_layout(rect=(0, 0, 1, 0.94))
+
+
+Preserving sample-aware bin labels
+----------------------------------
+
+Sometimes samples should not be summed. Instead, each sample and bin should
+remain identifiable. This is useful for building sample-aware data vectors.
+
+.. code-block:: python
+
+   lenses = {
+       "LRG": lrg,
+       "ELG": elg,
+   }
+
+   labels = NZTomography.sample_bin_labels(lenses)
+   bins = NZTomography.sample_bins(lenses)
+
+   print(labels)
+
+
+Building sample-aware combinations
+----------------------------------
+
+Sample-aware combinations preserve both the sample name and the bin index.
+
+.. code-block:: python
+
+   sources = {
+       "LSST": lsst_source,
+   }
+
+   lens_source_pairs = NZTomography.sample_combinations(
+       lenses,
+       sources,
+   )
+
+   print(lens_source_pairs)
+
+
+For example, if ``lenses`` contains DESI LRG and ELG bins, and ``sources``
+contains LSST source bins, the resulting labels have the form
+
+.. code-block:: python
+
+   (("LRG", 0), ("LSST", 0))
+   (("LRG", 1), ("LSST", 0))
+   (("ELG", 0), ("LSST", 0))
+
+These labels preserve both the sample identity and tomographic bin index.
+They can be passed directly to pair-selection routines, covariance builders,
+forecasting pipelines, or other downstream analyses without losing track of
+which physical sample each bin originated from.
+
+Summary
+-------
+
+Binny supports two complementary approaches for working with multiple
+tomographic samples:
+
+- ``combine_parent_nz`` combines parent redshift distributions;
+- ``combine_tomography_bins`` combines matching tomographic bins;
+- ``sample_bin_labels`` and ``sample_bins`` flatten multiple samples while
+  preserving sample identities;
+- ``sample_combinations`` constructs sample-aware combinations across one or
+  more collections.
+
+Together, these utilities make it possible to either merge samples into a
+single effective population or preserve their identities for analyses that
+require sample-aware bookkeeping.

--- a/src/binny/api/nz_tomography.py
+++ b/src/binny/api/nz_tomography.py
@@ -34,6 +34,21 @@ from binny.nz.registry import nz_model as _nz_model
 from binny.nz_tomo._tomography_bins import TomographyBins
 from binny.nz_tomo.bin_stats import population_stats as _population_stats
 from binny.nz_tomo.bin_stats import shape_stats as _shape_stats
+from binny.nz_tomo.sample_composition import (
+    combine_parent_nz as _combine_parent_nz,
+)
+from binny.nz_tomo.sample_composition import (
+    combine_tomography_bins as _combine_tomography_bins,
+)
+from binny.nz_tomo.sample_composition import (
+    sample_bin_labels as _sample_bin_labels,
+)
+from binny.nz_tomo.sample_composition import (
+    sample_bins as _sample_bins,
+)
+from binny.nz_tomo.sample_composition import (
+    sample_combinations as _sample_combinations,
+)
 from binny.surveys.survey_presets import (
     list_survey_configs,
     load_survey_config,
@@ -166,6 +181,55 @@ class NZTomography:
         """
         self._require_state()
         return self._parent["nz"]
+
+    @staticmethod
+    def combine_parent_nz(
+        samples: Sequence[Mapping[str, Any]],
+        *,
+        interpolate: bool = False,
+        z_target: np.ndarray | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Combine parent redshift distributions into one parent sample."""
+        return _combine_parent_nz(
+            samples,
+            interpolate=interpolate,
+            z_target=z_target,
+        )
+
+    @staticmethod
+    def combine_tomography_bins(
+        samples: Sequence[TomographyBins],
+        *,
+        interpolate: bool = False,
+        z_target: np.ndarray | None = None,
+    ) -> TomographyBins:
+        """Combine matching tomographic samples into one ``TomographyBins`` object."""
+        return _combine_tomography_bins(
+            samples,
+            interpolate=interpolate,
+            z_target=z_target,
+        )
+
+    @staticmethod
+    def sample_bin_labels(
+        samples: Mapping[str, TomographyBins],
+    ) -> list[tuple[str, int]]:
+        """Return flattened ``(sample_name, bin_index)`` labels."""
+        return _sample_bin_labels(samples)
+
+    @staticmethod
+    def sample_bins(
+        samples: Mapping[str, TomographyBins],
+    ) -> dict[tuple[str, int], np.ndarray]:
+        """Return flattened bins keyed by ``(sample_name, bin_index)``."""
+        return _sample_bins(samples)
+
+    @staticmethod
+    def sample_combinations(
+        *collections: Mapping[str, TomographyBins],
+    ) -> list[tuple[tuple[str, int], ...]]:
+        """Return all bin combinations across any number of sample collections."""
+        return _sample_combinations(*collections)
 
     def clear(self) -> None:
         """Clears the cached parent distribution, spec, bins, and metadata."""

--- a/src/binny/nz_tomo/sample_composition.py
+++ b/src/binny/nz_tomo/sample_composition.py
@@ -1,0 +1,192 @@
+"""Utilities for combining and flattening tomographic redshift samples.
+
+This module provides helpers for working with multiple ``TomographyBins``
+objects as one logical sample collection. It supports summing parent redshift
+distributions, interpolating samples onto a shared grid, combining matching
+tomographic bins, flattening sample/bin labels, and building sample-aware bin
+combinations for downstream correlation or data-vector construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from itertools import product
+from typing import Any
+
+import numpy as np
+
+from binny.nz_tomo._tomography_bins import TomographyBins
+
+
+def combine_parent_nz(
+    samples: Sequence[Mapping[str, Any]],
+    *,
+    interpolate: bool = False,
+    z_target: np.ndarray | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Combine parent redshift distributions into one parent sample."""
+    if len(samples) == 0:
+        raise ValueError("At least one sample is required.")
+
+    z0 = (
+        np.asarray(samples[0]["z"], dtype=float)
+        if z_target is None
+        else np.asarray(z_target, dtype=float)
+    )
+    nz_total = np.zeros_like(z0, dtype=float)
+
+    for sample in samples:
+        z = np.asarray(sample["z"], dtype=float)
+        nz = np.asarray(sample["nz"], dtype=float)
+
+        if interpolate:
+            nz = np.interp(z0, z, nz, left=0.0, right=0.0)
+        elif z.shape != z0.shape or not np.allclose(z, z0):
+            raise ValueError(
+                "All samples must use the same z grid. "
+                "Use interpolate=True to combine samples on a common grid."
+            )
+
+        nz_total += nz
+
+    return z0, nz_total
+
+
+def interpolate_tomography_bins(
+    sample: TomographyBins,
+    z_target: np.ndarray,
+) -> TomographyBins:
+    """Interpolate a tomographic sample onto a target redshift grid."""
+    z = np.asarray(sample.z, dtype=float)
+    z_target = np.asarray(z_target, dtype=float)
+
+    return TomographyBins(
+        z=z_target,
+        nz=np.interp(
+            z_target,
+            z,
+            np.asarray(sample.nz, dtype=float),
+            left=0.0,
+            right=0.0,
+        ),
+        spec=sample.spec,
+        bins={
+            k: np.interp(
+                z_target,
+                z,
+                np.asarray(nz_bin, dtype=float),
+                left=0.0,
+                right=0.0,
+            )
+            for k, nz_bin in sample.bins.items()
+        },
+        tomo_meta=sample.tomo_meta,
+        survey_meta=sample.survey_meta,
+        survey=sample.survey,
+    )
+
+
+def combine_tomography_bins(
+    samples: Sequence[TomographyBins],
+    *,
+    interpolate: bool = False,
+    z_target: np.ndarray | None = None,
+) -> TomographyBins:
+    """Combine matching tomographic samples into one ``TomographyBins`` object."""
+    if len(samples) == 0:
+        raise ValueError("At least one TomographyBins object is required.")
+
+    z0 = (
+        np.asarray(samples[0].z, dtype=float)
+        if z_target is None
+        else np.asarray(z_target, dtype=float)
+    )
+
+    if interpolate:
+        samples = [interpolate_tomography_bins(sample, z0) for sample in samples]
+
+    first = samples[0]
+    keys0 = list(first.bins.keys())
+
+    combined_bins = {k: np.zeros_like(z0, dtype=float) for k in keys0}
+    combined_nz = np.zeros_like(z0, dtype=float)
+
+    for sample in samples:
+        z = np.asarray(sample.z, dtype=float)
+
+        if z.shape != z0.shape or not np.allclose(z, z0):
+            raise ValueError(
+                "All samples must use the same z grid. "
+                "Use interpolate=True to combine samples on a common grid."
+            )
+
+        if list(sample.bins.keys()) != keys0:
+            raise ValueError("All samples must have the same bin keys.")
+
+        combined_nz += np.asarray(sample.nz, dtype=float)
+
+        for k in keys0:
+            combined_bins[k] += np.asarray(sample.bins[k], dtype=float)
+
+    return TomographyBins(
+        z=z0,
+        nz=combined_nz,
+        spec={"kind": "combined", "source": "combined_tomography_bins"},
+        bins=combined_bins,
+        tomo_meta=None,
+        survey_meta=None,
+        survey=None,
+    )
+
+
+def sample_bin_labels(
+    samples: Mapping[str, TomographyBins],
+) -> list[tuple[str, int]]:
+    """Return sample-aware labels for all tomographic bins."""
+    _check_shared_z_grid(samples)
+
+    return [
+        (sample_name, bin_index)
+        for sample_name, sample in samples.items()
+        for bin_index in sample.bins
+    ]
+
+
+def sample_bins(
+    samples: Mapping[str, TomographyBins],
+) -> dict[tuple[str, int], np.ndarray]:
+    """Return tomographic bins keyed by sample-aware bin labels."""
+    _check_shared_z_grid(samples)
+
+    return {
+        (sample_name, bin_index): np.asarray(nz_bin, dtype=float)
+        for sample_name, sample in samples.items()
+        for bin_index, nz_bin in sample.bins.items()
+    }
+
+
+def sample_combinations(
+    *collections: Mapping[str, TomographyBins],
+) -> list[tuple[tuple[str, int], ...]]:
+    """Return sample-aware bin-label combinations across sample collections."""
+    if len(collections) == 0:
+        raise ValueError("At least one sample collection is required.")
+
+    return [
+        combo for combo in product(*(sample_bin_labels(collection) for collection in collections))
+    ]
+
+
+def _check_shared_z_grid(samples: Mapping[str, TomographyBins]) -> None:
+    """Check that all samples in a collection share one redshift grid."""
+    if not samples:
+        raise ValueError("At least one sample is required.")
+
+    first = next(iter(samples.values()))
+    z0 = np.asarray(first.z, dtype=float)
+
+    for name, sample in samples.items():
+        z = np.asarray(sample.z, dtype=float)
+
+        if z.shape != z0.shape or not np.allclose(z, z0):
+            raise ValueError(f"Sample {name!r} does not share the same z grid.")

--- a/tests/test_api_nz_tomography.py
+++ b/tests/test_api_nz_tomography.py
@@ -1119,3 +1119,136 @@ def test_builtin_survey_configs_can_be_loaded(survey):
     assert "tomography" in cfg
     assert isinstance(cfg["tomography"], list)
     assert len(cfg["tomography"]) > 0
+
+
+def test_combine_parent_nz_delegates(monkeypatch):
+    """Tests that combine_parent_nz delegates to sample_composition."""
+    called = {}
+
+    def fake_combine_parent_nz(samples, *, interpolate=False, z_target=None):
+        called["samples"] = samples
+        called["interpolate"] = interpolate
+        called["z_target"] = z_target
+        return np.array([0.0, 1.0]), np.array([3.0, 4.0])
+
+    monkeypatch.setattr(
+        "binny.api.nz_tomography._combine_parent_nz",
+        fake_combine_parent_nz,
+        raising=True,
+    )
+
+    samples = [{"z": np.array([0.0, 1.0]), "nz": np.array([1.0, 2.0])}]
+    z_target = np.array([0.0, 0.5, 1.0])
+
+    z, nz = NZTomography.combine_parent_nz(
+        samples,
+        interpolate=True,
+        z_target=z_target,
+    )
+
+    assert called["samples"] is samples
+    assert called["interpolate"] is True
+    assert np.allclose(called["z_target"], z_target)
+    assert np.allclose(z, [0.0, 1.0])
+    assert np.allclose(nz, [3.0, 4.0])
+
+
+def test_combine_tomography_bins_delegates(monkeypatch):
+    """Tests that combine_tomography_bins delegates to sample_composition."""
+    called = {}
+    result = object()
+
+    def fake_combine_tomography_bins(samples, *, interpolate=False, z_target=None):
+        called["samples"] = samples
+        called["interpolate"] = interpolate
+        called["z_target"] = z_target
+        return result
+
+    monkeypatch.setattr(
+        "binny.api.nz_tomography._combine_tomography_bins",
+        fake_combine_tomography_bins,
+        raising=True,
+    )
+
+    samples = [object(), object()]
+    z_target = np.array([0.0, 0.5, 1.0])
+
+    out = NZTomography.combine_tomography_bins(
+        samples,
+        interpolate=True,
+        z_target=z_target,
+    )
+
+    assert out is result
+    assert called["samples"] is samples
+    assert called["interpolate"] is True
+    assert np.allclose(called["z_target"], z_target)
+
+
+def test_sample_bin_labels_delegates(monkeypatch):
+    """Tests that sample_bin_labels delegates to sample_composition."""
+    called = {}
+
+    def fake_sample_bin_labels(samples):
+        called["samples"] = samples
+        return [("bgs", 0), ("lrg", 1)]
+
+    monkeypatch.setattr(
+        "binny.api.nz_tomography._sample_bin_labels",
+        fake_sample_bin_labels,
+        raising=True,
+    )
+
+    samples = {"bgs": object(), "lrg": object()}
+    out = NZTomography.sample_bin_labels(samples)
+
+    assert out == [("bgs", 0), ("lrg", 1)]
+    assert called["samples"] is samples
+
+
+def test_sample_bins_delegates(monkeypatch):
+    """Tests that sample_bins delegates to sample_composition."""
+    called = {}
+    expected = {
+        ("bgs", 0): np.array([1.0, 0.0]),
+        ("lrg", 1): np.array([0.0, 1.0]),
+    }
+
+    def fake_sample_bins(samples):
+        called["samples"] = samples
+        return expected
+
+    monkeypatch.setattr(
+        "binny.api.nz_tomography._sample_bins",
+        fake_sample_bins,
+        raising=True,
+    )
+
+    samples = {"bgs": object(), "lrg": object()}
+    out = NZTomography.sample_bins(samples)
+
+    assert out is expected
+    assert called["samples"] is samples
+
+
+def test_sample_combinations_delegates(monkeypatch):
+    """Tests that sample_combinations delegates to sample_composition."""
+    called = {}
+
+    def fake_sample_combinations(*collections):
+        called["collections"] = collections
+        return [(("lens", 0), ("source", 1))]
+
+    monkeypatch.setattr(
+        "binny.api.nz_tomography._sample_combinations",
+        fake_sample_combinations,
+        raising=True,
+    )
+
+    lenses = {"lens": object()}
+    sources = {"source": object()}
+
+    out = NZTomography.sample_combinations(lenses, sources)
+
+    assert out == [(("lens", 0), ("source", 1))]
+    assert called["collections"] == (lenses, sources)

--- a/tests/test_nz_tomo_sample_composition.py
+++ b/tests/test_nz_tomo_sample_composition.py
@@ -1,0 +1,642 @@
+"""Unit tests for ``binny.nz_tomo.sample_composition``."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from binny.nz_tomo._tomography_bins import TomographyBins
+from binny.nz_tomo.sample_composition import (
+    combine_parent_nz,
+    combine_tomography_bins,
+    interpolate_tomography_bins,
+    sample_bin_labels,
+    sample_bins,
+    sample_combinations,
+)
+
+
+def make_tomo(
+    *,
+    z: np.ndarray,
+    nz: np.ndarray,
+    bins: dict[int, np.ndarray],
+    survey: str = "mock",
+) -> TomographyBins:
+    """Tests use a small tomography object."""
+    return TomographyBins(
+        z=z,
+        nz=nz,
+        spec={"kind": "test"},
+        bins=bins,
+        tomo_meta={"tomo": "meta"},
+        survey_meta={"survey": "meta"},
+        survey=survey,
+    )
+
+
+def test_combine_parent_nz_sums_survey_like_samples() -> None:
+    """Tests that parent n(z) curves from multiple samples are summed."""
+    z = np.linspace(0.0, 2.0, 5)
+
+    bgs = {"z": z, "nz": np.array([0.0, 1.0, 2.0, 1.0, 0.0])}
+    lrg = {"z": z, "nz": np.array([0.0, 0.5, 1.5, 2.0, 0.5])}
+
+    z_out, nz_out = combine_parent_nz([bgs, lrg])
+
+    np.testing.assert_allclose(z_out, z)
+    np.testing.assert_allclose(nz_out, bgs["nz"] + lrg["nz"])
+
+
+def test_combine_parent_nz_interpolates_to_first_grid() -> None:
+    """Tests that parent samples can be interpolated onto the first grid."""
+    z0 = np.array([0.0, 0.5, 1.0])
+    z1 = np.array([0.0, 1.0])
+
+    sample_a = {"z": z0, "nz": np.array([0.0, 1.0, 0.0])}
+    sample_b = {"z": z1, "nz": np.array([0.0, 2.0])}
+
+    z_out, nz_out = combine_parent_nz([sample_a, sample_b], interpolate=True)
+
+    np.testing.assert_allclose(z_out, z0)
+    np.testing.assert_allclose(nz_out, np.array([0.0, 2.0, 2.0]))
+
+
+def test_combine_parent_nz_interpolates_to_target_grid() -> None:
+    """Tests that parent samples can be interpolated onto a target grid."""
+    z_target = np.array([0.0, 0.25, 0.5, 0.75, 1.0])
+
+    samples = [
+        {"z": np.array([0.0, 1.0]), "nz": np.array([0.0, 2.0])},
+        {"z": np.array([0.0, 0.5, 1.0]), "nz": np.array([0.0, 1.0, 0.0])},
+    ]
+
+    z_out, nz_out = combine_parent_nz(
+        samples,
+        interpolate=True,
+        z_target=z_target,
+    )
+
+    expected = np.array([0.0, 0.5, 1.0, 1.5, 2.0])
+    expected += np.array([0.0, 0.5, 1.0, 0.5, 0.0])
+
+    np.testing.assert_allclose(z_out, z_target)
+    np.testing.assert_allclose(nz_out, expected)
+
+
+def test_combine_parent_nz_rejects_mismatched_redshift_grid() -> None:
+    """Tests that parent samples must share one redshift grid."""
+    samples = [
+        {"z": np.array([0.0, 0.5, 1.0]), "nz": np.ones(3)},
+        {"z": np.array([0.0, 0.6, 1.0]), "nz": np.ones(3)},
+    ]
+
+    with pytest.raises(ValueError, match="same z grid"):
+        combine_parent_nz(samples)
+
+
+def test_combine_parent_nz_rejects_empty_input() -> None:
+    """Tests that combining parent samples requires at least one sample."""
+    with pytest.raises(ValueError, match="At least one sample"):
+        combine_parent_nz([])
+
+
+def test_interpolate_tomography_bins_maps_parent_and_bins() -> None:
+    """Tests that a tomography object is interpolated onto a target grid."""
+    z = np.array([0.0, 1.0])
+    z_target = np.array([0.0, 0.5, 1.0, 1.5])
+
+    sample = make_tomo(
+        z=z,
+        nz=np.array([0.0, 2.0]),
+        bins={0: np.array([0.0, 1.0]), 1: np.array([2.0, 0.0])},
+        survey="BGS",
+    )
+
+    out = interpolate_tomography_bins(sample, z_target)
+
+    np.testing.assert_allclose(out.z, z_target)
+    np.testing.assert_allclose(out.nz, np.array([0.0, 1.0, 2.0, 0.0]))
+    np.testing.assert_allclose(out.bins[0], np.array([0.0, 0.5, 1.0, 0.0]))
+    np.testing.assert_allclose(out.bins[1], np.array([2.0, 1.0, 0.0, 0.0]))
+
+    assert out.spec == sample.spec
+    assert out.tomo_meta == sample.tomo_meta
+    assert out.survey_meta == sample.survey_meta
+    assert out.survey == "BGS"
+
+
+def test_combine_tomography_bins_sums_matching_bins_and_parent_nz() -> None:
+    """Tests that matching tomographic bins are summed bin-by-bin."""
+    z = np.linspace(0.0, 2.0, 5)
+
+    bgs = make_tomo(
+        z=z,
+        nz=np.array([0.0, 1.0, 2.0, 1.0, 0.0]),
+        bins={
+            0: np.array([0.0, 1.0, 0.5, 0.0, 0.0]),
+            1: np.array([0.0, 0.0, 1.5, 1.0, 0.0]),
+        },
+        survey="BGS",
+    )
+    lrg = make_tomo(
+        z=z,
+        nz=np.array([0.0, 0.5, 1.5, 2.0, 0.5]),
+        bins={
+            0: np.array([0.0, 0.5, 0.5, 0.0, 0.0]),
+            1: np.array([0.0, 0.0, 1.0, 2.0, 0.5]),
+        },
+        survey="LRG",
+    )
+
+    combined = combine_tomography_bins([bgs, lrg])
+
+    np.testing.assert_allclose(combined.z, z)
+    np.testing.assert_allclose(combined.nz, bgs.nz + lrg.nz)
+    np.testing.assert_allclose(combined.bins[0], bgs.bins[0] + lrg.bins[0])
+    np.testing.assert_allclose(combined.bins[1], bgs.bins[1] + lrg.bins[1])
+
+    assert combined.spec == {
+        "kind": "combined",
+        "source": "combined_tomography_bins",
+    }
+    assert combined.survey is None
+
+
+def test_combine_tomography_bins_interpolates_to_first_grid() -> None:
+    """Tests that matching tomographic bins can be interpolated and summed."""
+    z0 = np.array([0.0, 0.5, 1.0])
+    z1 = np.array([0.0, 1.0])
+
+    sample_a = make_tomo(
+        z=z0,
+        nz=np.array([0.0, 1.0, 0.0]),
+        bins={0: np.array([0.0, 1.0, 0.0])},
+    )
+    sample_b = make_tomo(
+        z=z1,
+        nz=np.array([0.0, 2.0]),
+        bins={0: np.array([0.0, 4.0])},
+    )
+
+    combined = combine_tomography_bins([sample_a, sample_b], interpolate=True)
+
+    np.testing.assert_allclose(combined.z, z0)
+    np.testing.assert_allclose(combined.nz, np.array([0.0, 2.0, 2.0]))
+    np.testing.assert_allclose(combined.bins[0], np.array([0.0, 3.0, 4.0]))
+
+
+def test_combine_tomography_bins_interpolates_to_target_grid() -> None:
+    """Tests that matching tomographic bins can use a requested target grid."""
+    z_target = np.array([0.0, 0.5, 1.0])
+
+    sample_a = make_tomo(
+        z=np.array([0.0, 1.0]),
+        nz=np.array([0.0, 2.0]),
+        bins={0: np.array([0.0, 4.0])},
+    )
+    sample_b = make_tomo(
+        z=np.array([0.0, 0.5, 1.0]),
+        nz=np.array([0.0, 1.0, 0.0]),
+        bins={0: np.array([0.0, 2.0, 0.0])},
+    )
+
+    combined = combine_tomography_bins(
+        [sample_a, sample_b],
+        interpolate=True,
+        z_target=z_target,
+    )
+
+    np.testing.assert_allclose(combined.z, z_target)
+    np.testing.assert_allclose(combined.nz, np.array([0.0, 2.0, 2.0]))
+    np.testing.assert_allclose(combined.bins[0], np.array([0.0, 4.0, 4.0]))
+
+
+def test_combine_tomography_bins_rejects_mismatched_redshift_grid() -> None:
+    """Tests that tomographic samples must share one redshift grid."""
+    sample_a = make_tomo(
+        z=np.array([0.0, 0.5, 1.0]),
+        nz=np.ones(3),
+        bins={0: np.ones(3)},
+    )
+    sample_b = make_tomo(
+        z=np.array([0.0, 0.6, 1.0]),
+        nz=np.ones(3),
+        bins={0: np.ones(3)},
+    )
+
+    with pytest.raises(ValueError, match="same z grid"):
+        combine_tomography_bins([sample_a, sample_b])
+
+
+def test_combine_tomography_bins_rejects_mismatched_bin_keys() -> None:
+    """Tests that tomographic samples must have the same bin labels."""
+    z = np.linspace(0.0, 1.0, 3)
+
+    sample_a = make_tomo(
+        z=z,
+        nz=np.ones(3),
+        bins={0: np.ones(3), 1: np.ones(3)},
+    )
+    sample_b = make_tomo(
+        z=z,
+        nz=np.ones(3),
+        bins={0: np.ones(3), 2: np.ones(3)},
+    )
+
+    with pytest.raises(ValueError, match="same bin keys"):
+        combine_tomography_bins([sample_a, sample_b])
+
+
+def test_combine_tomography_bins_rejects_empty_input() -> None:
+    """Tests that combining tomography objects requires at least one sample."""
+    with pytest.raises(ValueError, match="At least one TomographyBins"):
+        combine_tomography_bins([])
+
+
+def test_sample_bin_labels_preserve_sample_identity() -> None:
+    """Tests that equal bin indices from different samples remain distinct."""
+    z = np.linspace(0.0, 1.0, 3)
+
+    samples = {
+        "BGS": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)}),
+        "LRG": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3), 1: np.ones(3)}),
+    }
+
+    assert sample_bin_labels(samples) == [
+        ("BGS", 0),
+        ("LRG", 0),
+        ("LRG", 1),
+    ]
+
+
+def test_sample_bins_returns_flat_sample_aware_bin_dictionary() -> None:
+    """Tests that flattened bins are keyed by sample name and bin index."""
+    z = np.linspace(0.0, 1.0, 3)
+
+    bgs_bin = np.array([0.0, 1.0, 0.0])
+    lrg_bin = np.array([0.0, 0.5, 0.5])
+
+    samples = {
+        "BGS": make_tomo(z=z, nz=np.ones(3), bins={0: bgs_bin}),
+        "LRG": make_tomo(z=z, nz=np.ones(3), bins={0: lrg_bin}),
+    }
+
+    bins = sample_bins(samples)
+
+    assert list(bins) == [("BGS", 0), ("LRG", 0)]
+    np.testing.assert_allclose(bins[("BGS", 0)], bgs_bin)
+    np.testing.assert_allclose(bins[("LRG", 0)], lrg_bin)
+
+
+def test_sample_combinations_builds_lens_source_pairs() -> None:
+    """Tests that sample-aware lens-source pair labels are generated."""
+    z = np.linspace(0.0, 2.0, 5)
+
+    lenses = {
+        "BGS": make_tomo(z=z, nz=np.ones(5), bins={0: np.ones(5)}),
+        "LRG": make_tomo(z=z, nz=np.ones(5), bins={0: np.ones(5), 1: np.ones(5)}),
+    }
+    sources = {
+        "LSST": make_tomo(z=z, nz=np.ones(5), bins={0: np.ones(5), 1: np.ones(5)}),
+    }
+
+    pairs = sample_combinations(lenses, sources)
+
+    assert pairs == [
+        (("BGS", 0), ("LSST", 0)),
+        (("BGS", 0), ("LSST", 1)),
+        (("LRG", 0), ("LSST", 0)),
+        (("LRG", 0), ("LSST", 1)),
+        (("LRG", 1), ("LSST", 0)),
+        (("LRG", 1), ("LSST", 1)),
+    ]
+
+
+def test_sample_combinations_supports_three_collections() -> None:
+    """Tests that combinations work beyond simple lens-source pairs."""
+    z = np.linspace(0.0, 1.0, 3)
+
+    lenses = {"LRG": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)})}
+    sources = {"LSST": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)})}
+    probes = {
+        "shear": make_tomo(
+            z=z,
+            nz=np.ones(3),
+            bins={0: np.ones(3), 1: np.ones(3)},
+        )
+    }
+
+    combos = sample_combinations(lenses, sources, probes)
+
+    assert combos == [
+        (("LRG", 0), ("LSST", 0), ("shear", 0)),
+        (("LRG", 0), ("LSST", 0), ("shear", 1)),
+    ]
+
+
+def test_sample_combinations_rejects_no_collections() -> None:
+    """Tests that at least one collection is required."""
+    with pytest.raises(ValueError, match="At least one sample collection"):
+        sample_combinations()
+
+
+def test_sample_helpers_reject_empty_collection() -> None:
+    """Tests that flattened sample helpers require at least one sample."""
+    with pytest.raises(ValueError, match="At least one sample"):
+        sample_bin_labels({})
+
+    with pytest.raises(ValueError, match="At least one sample"):
+        sample_bins({})
+
+
+def test_sample_helpers_reject_mismatched_z_grid_with_sample_name() -> None:
+    """Tests that grid validation reports the offending sample name."""
+    samples = {
+        "BGS": make_tomo(
+            z=np.array([0.0, 0.5, 1.0]),
+            nz=np.ones(3),
+            bins={0: np.ones(3)},
+        ),
+        "LRG": make_tomo(
+            z=np.array([0.0, 0.6, 1.0]),
+            nz=np.ones(3),
+            bins={0: np.ones(3)},
+        ),
+    }
+
+    with pytest.raises(ValueError, match="Sample 'LRG'"):
+        sample_bin_labels(samples)
+
+
+def test_combine_parent_nz_interpolation_zeros_outside_input_range() -> None:
+    """Tests that interpolation does not extrapolate parent samples."""
+    z_target = np.array([-1.0, 0.0, 0.5, 1.0, 2.0])
+    sample = {"z": np.array([0.0, 1.0]), "nz": np.array([2.0, 4.0])}
+
+    _, nz_out = combine_parent_nz(
+        [sample],
+        interpolate=True,
+        z_target=z_target,
+    )
+
+    np.testing.assert_allclose(nz_out, np.array([0.0, 2.0, 3.0, 4.0, 0.0]))
+
+
+def test_combine_parent_nz_uses_target_grid_even_without_interpolation() -> None:
+    """Tests that z_target is accepted when it matches the sample grid."""
+    z = np.array([0.0, 0.5, 1.0])
+    sample = {"z": z, "nz": np.array([1.0, 2.0, 3.0])}
+
+    z_out, nz_out = combine_parent_nz([sample], z_target=z.copy())
+
+    np.testing.assert_allclose(z_out, z)
+    np.testing.assert_allclose(nz_out, sample["nz"])
+
+
+def test_combine_parent_nz_rejects_target_grid_without_interpolation_if_different() -> None:
+    """Tests that z_target requires interpolation when grids differ."""
+    sample = {
+        "z": np.array([0.0, 1.0]),
+        "nz": np.array([1.0, 2.0]),
+    }
+
+    with pytest.raises(ValueError, match="Use interpolate=True"):
+        combine_parent_nz(
+            [sample],
+            z_target=np.array([0.0, 0.5, 1.0]),
+        )
+
+
+def test_interpolate_tomography_bins_zeros_outside_input_range() -> None:
+    """Tests that tomography interpolation does not extrapolate."""
+    sample = make_tomo(
+        z=np.array([0.0, 1.0]),
+        nz=np.array([2.0, 4.0]),
+        bins={0: np.array([1.0, 3.0])},
+    )
+
+    out = interpolate_tomography_bins(
+        sample,
+        np.array([-1.0, 0.0, 0.5, 1.0, 2.0]),
+    )
+
+    np.testing.assert_allclose(out.nz, np.array([0.0, 2.0, 3.0, 4.0, 0.0]))
+    np.testing.assert_allclose(out.bins[0], np.array([0.0, 1.0, 2.0, 3.0, 0.0]))
+
+
+def test_combine_tomography_bins_preserves_bin_key_order() -> None:
+    """Tests that combined tomography bins preserve the first sample key order."""
+    z = np.array([0.0, 0.5, 1.0])
+
+    sample_a = make_tomo(
+        z=z,
+        nz=np.ones(3),
+        bins={2: np.ones(3), 0: 2.0 * np.ones(3)},
+    )
+    sample_b = make_tomo(
+        z=z,
+        nz=np.ones(3),
+        bins={2: 3.0 * np.ones(3), 0: 4.0 * np.ones(3)},
+    )
+
+    combined = combine_tomography_bins([sample_a, sample_b])
+
+    assert list(combined.bins) == [2, 0]
+    np.testing.assert_allclose(combined.bins[2], 4.0 * np.ones(3))
+    np.testing.assert_allclose(combined.bins[0], 6.0 * np.ones(3))
+
+
+def test_combine_tomography_bins_rejects_same_keys_in_different_order() -> None:
+    """Tests that bin key order must match exactly."""
+    z = np.array([0.0, 0.5, 1.0])
+
+    sample_a = make_tomo(
+        z=z,
+        nz=np.ones(3),
+        bins={0: np.ones(3), 1: np.ones(3)},
+    )
+    sample_b = make_tomo(
+        z=z,
+        nz=np.ones(3),
+        bins={1: np.ones(3), 0: np.ones(3)},
+    )
+
+    with pytest.raises(ValueError, match="same bin keys"):
+        combine_tomography_bins([sample_a, sample_b])
+
+
+def test_combine_tomography_bins_rejects_target_grid_without_interpolation_if_different() -> None:
+    """Tests that z_target requires interpolation when tomography grids differ."""
+    sample = make_tomo(
+        z=np.array([0.0, 1.0]),
+        nz=np.ones(2),
+        bins={0: np.ones(2)},
+    )
+
+    with pytest.raises(ValueError, match="Use interpolate=True"):
+        combine_tomography_bins(
+            [sample],
+            z_target=np.array([0.0, 0.5, 1.0]),
+        )
+
+
+def test_sample_bin_labels_preserve_sample_and_bin_insertion_order() -> None:
+    """Tests that flattened labels follow mapping and bin insertion order."""
+    z = np.array([0.0, 0.5, 1.0])
+
+    samples = {
+        "sample_a": make_tomo(z=z, nz=np.ones(3), bins={2: np.ones(3), 0: np.ones(3)}),
+        "sample_b": make_tomo(z=z, nz=np.ones(3), bins={1: np.ones(3)}),
+    }
+
+    assert sample_bin_labels(samples) == [
+        ("sample_a", 2),
+        ("sample_a", 0),
+        ("sample_b", 1),
+    ]
+
+
+def test_sample_bins_returns_float_arrays_without_mutating_inputs() -> None:
+    """Tests that flattened bins are float arrays copied from input values."""
+    z = np.array([0.0, 0.5, 1.0])
+    original = np.array([0, 1, 2], dtype=int)
+
+    samples = {
+        "sample": make_tomo(
+            z=z,
+            nz=np.ones(3),
+            bins={0: original},
+        )
+    }
+
+    bins = sample_bins(samples)
+
+    assert bins[("sample", 0)].dtype == float
+    np.testing.assert_allclose(bins[("sample", 0)], original)
+
+
+def test_sample_combinations_with_one_collection_returns_single_labels() -> None:
+    """Tests that combinations work for one sample collection."""
+    z = np.array([0.0, 0.5, 1.0])
+    samples = {
+        "sample": make_tomo(
+            z=z,
+            nz=np.ones(3),
+            bins={0: np.ones(3), 1: np.ones(3)},
+        )
+    }
+
+    combos = sample_combinations(samples)
+
+    assert combos == [
+        (("sample", 0),),
+        (("sample", 1),),
+    ]
+
+
+def test_sample_combinations_rejects_empty_collection_inside_product() -> None:
+    """Tests that empty collections are rejected inside combinations."""
+    z = np.array([0.0, 0.5, 1.0])
+    samples = {
+        "sample": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)}),
+    }
+
+    with pytest.raises(ValueError, match="At least one sample"):
+        sample_combinations(samples, {})
+
+
+def test_combine_parent_nz_sums_more_than_two_samples() -> None:
+    """Tests that parent n(z) curves sum across more than two samples."""
+    z = np.array([0.0, 0.5, 1.0])
+
+    samples = [
+        {"z": z, "nz": np.array([1.0, 2.0, 3.0])},
+        {"z": z, "nz": np.array([0.5, 1.0, 1.5])},
+        {"z": z, "nz": np.array([2.0, 0.0, 1.0])},
+    ]
+
+    z_out, nz_out = combine_parent_nz(samples)
+
+    np.testing.assert_allclose(z_out, z)
+    np.testing.assert_allclose(nz_out, np.array([3.5, 3.0, 5.5]))
+
+
+def test_combine_tomography_bins_sums_more_than_two_samples() -> None:
+    """Tests that tomography bins sum across more than two samples."""
+    z = np.array([0.0, 0.5, 1.0])
+
+    sample_a = make_tomo(
+        z=z,
+        nz=np.array([1.0, 2.0, 3.0]),
+        bins={
+            0: np.array([1.0, 0.0, 0.0]),
+            1: np.array([0.0, 1.0, 0.0]),
+        },
+    )
+    sample_b = make_tomo(
+        z=z,
+        nz=np.array([0.5, 1.0, 1.5]),
+        bins={
+            0: np.array([0.5, 0.5, 0.0]),
+            1: np.array([0.0, 0.5, 0.5]),
+        },
+    )
+    sample_c = make_tomo(
+        z=z,
+        nz=np.array([2.0, 0.0, 1.0]),
+        bins={
+            0: np.array([2.0, 0.0, 1.0]),
+            1: np.array([1.0, 0.0, 0.0]),
+        },
+    )
+
+    combined = combine_tomography_bins([sample_a, sample_b, sample_c])
+
+    np.testing.assert_allclose(combined.z, z)
+    np.testing.assert_allclose(combined.nz, np.array([3.5, 3.0, 5.5]))
+    np.testing.assert_allclose(combined.bins[0], np.array([3.5, 0.5, 1.0]))
+    np.testing.assert_allclose(combined.bins[1], np.array([1.0, 1.5, 0.5]))
+
+
+def test_sample_bin_labels_preserve_three_sample_identities() -> None:
+    """Tests that labels preserve identities for more than two samples."""
+    z = np.array([0.0, 0.5, 1.0])
+
+    samples = {
+        "BGS": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)}),
+        "LRG": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3), 1: np.ones(3)}),
+        "ELG": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)}),
+    }
+
+    assert sample_bin_labels(samples) == [
+        ("BGS", 0),
+        ("LRG", 0),
+        ("LRG", 1),
+        ("ELG", 0),
+    ]
+
+
+def test_sample_combinations_builds_pairs_from_more_than_two_samples_per_collection() -> None:
+    """Tests that combinations expand all samples in each collection."""
+    z = np.array([0.0, 0.5, 1.0])
+
+    lenses = {
+        "BGS": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)}),
+        "LRG": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)}),
+        "ELG": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3)}),
+    }
+    sources = {
+        "LSST": make_tomo(z=z, nz=np.ones(3), bins={0: np.ones(3), 1: np.ones(3)}),
+    }
+
+    pairs = sample_combinations(lenses, sources)
+
+    assert pairs == [
+        (("BGS", 0), ("LSST", 0)),
+        (("BGS", 0), ("LSST", 1)),
+        (("LRG", 0), ("LSST", 0)),
+        (("LRG", 0), ("LSST", 1)),
+        (("ELG", 0), ("LSST", 0)),
+        (("ELG", 0), ("LSST", 1)),
+    ]


### PR DESCRIPTION
Closes #72.

This PR adds support for combining multiple tomographic samples into a single effective sample. Users can now either combine parent redshift distributions before tomography or combine matching tomographic bins after tomography.

The implementation introduces utilities for:

* Combining parent `n(z)` distributions across multiple samples
* Combining matching tomographic bins across multiple `TomographyBins` objects
* Building sample-aware bin labels and flattened bin dictionaries
* Constructing sample-aware combinations for downstream analyses

This enables workflows where samples such as DESI LRGs and ELGs can be treated either as separate tracer populations or as a single effective lens sample without requiring users to manually merge distributions outside Binny.

## Changes

* Added `sample_composition` utilities
* Added `NZTomography` API wrappers
* Added unit tests for composition utilities and API delegation
* Added documentation and examples demonstrating DESI LRG + ELG sample composition

## Example

```python
combined = NZTomography.combine_tomography_bins(
    [lrg_bins, elg_bins],
    interpolate=True,
)
```

or

```python
labels = NZTomography.sample_bin_labels(samples)
pairs = NZTomography.sample_combinations(lenses, sources)
```
